### PR TITLE
feat: add dry-run support and optional test timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,16 +11,15 @@ How to run tests safely (Dockerized):
 - Do not invoke Bats or individual test files directly on the host.
 - CI runs the same flow via the bash matrix. If you need distro-specific runs locally, use `ci-matrix/run-all.sh`.
  - Tests default to `SHIPLOG_USE_LOCAL_SANDBOX=1` (no network clones); set to `0` only if you explicitly need to hit the remote sandbox repo.
-## Test Timeouts (Required)
+## Test Timeouts
 
-- Always wrap local test runs with a timeout to prevent hangs:
-  - Linux: `timeout 180s make test`
-  - macOS (coreutils): `gtimeout 180s make test`
-- For signing-enabled runs, you may extend to 360s if needed.
-- In GitHub Actions, prefer the job/step timeout or wrap the command: `timeout 180s ./test.sh`.
+- The suite no longer enforces a timeout by default. Runs will continue until completion unless you opt in.
+- To enable a guard in any environment, set `TEST_TIMEOUT_SECS` to a positive integer (e.g., `TEST_TIMEOUT_SECS=180 make test`).
+- You can still wrap the outer `make test` call with `timeout`/`gtimeout` if you suspect a hang.
+- In CI, rely on the job/step timeout or export `TEST_TIMEOUT_SECS` for an additional safety net.
 - If a timeout occurs, capture and attach logs from `ci-logs/*` or the container output for debugging.
 
-Note: The repo’s `test.sh` enforces an internal timeout (`TEST_TIMEOUT_SECS`, default 180) and disables network clones by default (`SHIPLOG_USE_LOCAL_SANDBOX=1`) to keep runs bounded and deterministic.
+Note: The suite still defaults to the local sandbox (`SHIPLOG_USE_LOCAL_SANDBOX=1`) to avoid network clones.
 # Git Workflow Guidelines
 
 ## Quick Reminders

--- a/bin/git-shiplog
+++ b/bin/git-shiplog
@@ -113,9 +113,24 @@ run_with_global_flags() {
         export SHIPLOG_ASSUME_YES
         shift
         ;;
-     --boring)
+      --boring)
         SHIPLOG_BORING=1
         export SHIPLOG_BORING
+        shift
+        ;;
+      --dry-run)
+        SHIPLOG_DRY_RUN=1
+        export SHIPLOG_DRY_RUN
+        shift
+        ;;
+      --dry-run=*)
+        SHIPLOG_DRY_RUN="${1#*=}"
+        export SHIPLOG_DRY_RUN
+        shift
+        ;;
+      --no-dry-run)
+        SHIPLOG_DRY_RUN=0
+        export SHIPLOG_DRY_RUN
         shift
         ;;
       --help|-h)

--- a/docs/features/command-reference.md
+++ b/docs/features/command-reference.md
@@ -8,6 +8,7 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
 - `--boring` — Non-interactive mode (plain output; prompts disabled). Also `SHIPLOG_BORING=1`.
 - `--yes` — Auto-confirm prompts (sets `SHIPLOG_ASSUME_YES=1`).
 - `--no-push` / `--push` — Control auto-push behavior for commands that push refs.
+- `--dry-run` — Preview actions without updating Shiplog journals or notes (`SHIPLOG_DRY_RUN=1`).
 - `--version` `-V` — Print version and exit.
 - `--help` `-h` — Show usage.
 
@@ -28,12 +29,13 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
     - Interactive: `git shiplog write prod`
     - Non-interactive: `SHIPLOG_BORING=1 git shiplog --yes write prod`
   - Env: `SHIPLOG_SERVICE`, `SHIPLOG_STATUS`, `SHIPLOG_REASON`, `SHIPLOG_TICKET`, `SHIPLOG_REGION`, `SHIPLOG_CLUSTER`, `SHIPLOG_NAMESPACE`, `SHIPLOG_IMAGE`, `SHIPLOG_TAG`, `SHIPLOG_RUN_URL`, `SHIPLOG_LOG`, `SHIPLOG_AUTO_PUSH`.
+  - Flags: accepts `--dry-run` to preview the entry after prompts without appending to the journal or pushing notes.
   - Effects: honors allowlists/signing per policy; pushes journal (+notes) to origin unless disabled.
 
 - `append [OPTIONS]`
   - Purpose: append a new entry non-interactively by supplying a JSON payload via CLI, stdin, or file.
   - Usage: `printf '{"deployment":"green"}' | git shiplog append --service deploy --status success --json -`
-  - Flags: mirrors `write` (`--service`, `--status`, `--reason`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--image`, `--tag`, `--run-url`, `--log`, `--env`).
+  - Flags: mirrors `write` (`--service`, `--status`, `--reason`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--image`, `--tag`, `--run-url`, `--log`, `--env`, `--dry-run`).
   - Notes: sets `SHIPLOG_EXTRA_JSON` automatically with the provided object and runs `write` in boring/auto-confirm mode.
 
 - `run [OPTIONS] -- <command ...>`

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -67,6 +67,6 @@ See: docs/features/write.md for full semantics and examples.
 
 ## CI/Tests
 
-- `TEST_TIMEOUT_SECS` — In-container Bats timeout (seconds). Default: `180`.
+- `TEST_TIMEOUT_SECS` — Optional Bats timeout (seconds). Set to a positive integer to enable.
 - `BATS_FLAGS` — Extra flags for Bats (e.g., `--print-output-on-failure -T`).
 - `SHIPLOG_USE_LOCAL_SANDBOX` — `1` to avoid network clones in tests (default `1`).

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -61,6 +61,27 @@ shiplog_can_use_bosun() {
   shiplog_have_bosun
 }
 
+shiplog_is_dry_run() {
+  case "${SHIPLOG_DRY_RUN:-0}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+shiplog_dry_run_notice() {
+  local message="${1:-}"
+  if [ -z "$message" ]; then
+    message="Dry-run: no changes performed"
+  fi
+  if shiplog_can_use_bosun; then
+    local bosun
+    bosun=$(shiplog_bosun_bin)
+    "$bosun" style --title "Dry Run" -- "$message"
+  else
+    printf 'ℹ️ dry-run: %s\n' "$message"
+  fi
+}
+
 shiplog_log_structured() {
   printf '%s\n' "$1" >&2
 }

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -19,6 +19,10 @@ current_tip() { git rev-parse --verify "$1" 2>/dev/null || true; }
 
 ff_update() {
   local ref="$1" new="$2" old="$3" msg="${4:-append shiplog entry}"
+  if shiplog_is_dry_run; then
+    shiplog_dry_run_notice "Would update $ref"
+    return 0
+  fi
   git update-ref -m "$msg" "$ref" "$new" "${old:-0000000000000000000000000000000000000000}"
 }
 
@@ -181,6 +185,10 @@ sign_commit() {
 attach_note_if_present() {
   local commit="$1" log_path="${2:-}"
   [ -z "${log_path}" ] && return 0
+  if shiplog_is_dry_run; then
+    shiplog_dry_run_notice "Would attach note to $commit"
+    return 0
+  fi
   git notes --ref="$NOTES_REF" add -F "$log_path" "$commit"
 }
 

--- a/test/02_write_and_ls_show.bats
+++ b/test/02_write_and_ls_show.bats
@@ -36,6 +36,18 @@ teardown() {
   [[ "$output" == "Deploy: web"* ]]
 }
 
+@test "write --dry-run previews without writing" {
+  run git show-ref "${REF_ROOT}/journal/prod"
+  [ "$status" -ne 0 ]
+
+  run git shiplog --boring write --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would sign & append entry to ${REF_ROOT}/journal/prod"* ]]
+
+  run git show-ref "${REF_ROOT}/journal/prod"
+  [ "$status" -ne 0 ]
+}
+
 @test "ls shows a formatted table via bosun" {
   run git shiplog --yes write
   [ "$status" -eq 0 ]

--- a/test/10_run_command.bats
+++ b/test/10_run_command.bats
@@ -85,7 +85,7 @@ teardown() {
 
   run bash -lc 'git shiplog run --dry-run --service test --reason "no-op" -- touch dry-run-file'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"would execute: touch dry-run-file"* ]]
+  [[ "$output" == *"Would execute: touch dry-run-file"* ]]
   [ ! -e dry-run-file ]
 
   run git show-ref "${REF_ROOT}/journal/prod"

--- a/test/17_append_and_trust.bats
+++ b/test/17_append_and_trust.bats
@@ -50,6 +50,18 @@ teardown() {
   [ "$build" = "200" ]
 }
 
+@test "append --dry-run previews without writing" {
+  run bash -c "git show-ref ${REF_ROOT}/journal/prod"
+  [ "$status" -ne 0 ]
+
+  run bash -c "git shiplog append --dry-run --service api --status success --reason 'dry-run' --json '{\"build\":\"preview\"}'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would sign & append entry to ${REF_ROOT}/journal/prod"* ]]
+
+  run bash -c "git show-ref ${REF_ROOT}/journal/prod"
+  [ "$status" -ne 0 ]
+}
+
 @test "append accepts JSON from stdin" {
   local prev_env="${SHIPLOG_ENV:-prod}"
   local unique_env="prod-append-stdin-${BATS_TEST_NUMBER:-0}-${RANDOM}${RANDOM}"

--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ The `test/` directory contains the Bats-based integration suite that exercises t
 - `make test` builds the local Docker image (if needed) and runs all Bats files with signing disabled. The container mounts the workspace at `/workspace` and executes `/usr/local/bin/run-tests`.
 - The `run-tests` entrypoint copies the repo to a temporary snapshot inside the container and sets `SHIPLOG_HOME` to that snapshot to prevent accidental mutations of the bind mount.
 - Default test mode avoids network clones: `SHIPLOG_USE_LOCAL_SANDBOX=1` (set to `0` only if you explicitly need to hit the remote sandbox).
-- Timeout is enforced in-container: `TEST_TIMEOUT_SECS` (default `180`). You can add `BATS_FLAGS` (e.g., `--print-output-on-failure -T`) for verbose runs.
+- You can opt into an in-container timeout by setting `TEST_TIMEOUT_SECS` to a positive integer. Add `BATS_FLAGS` (e.g., `--print-output-on-failure -T`) for verbose runs.
 - `make test-signing` performs the same flow with `ENABLE_SIGNING=true`, generating a throw‑away GPG key inside the container to exercise signed‑commit verification.
 - The entrypoint installs `bin/git-shiplog` into `/usr/local/bin/git-shiplog` and exports `SHIPLOG_BOSUN_BIN`, then runs Bats (`bats -r`).
 - Each Bats file calls `load helpers/common`, whose `shiplog_install_cli` helper ensures the CLI is present and executable before tests begin.
@@ -47,7 +47,7 @@ The `test/` directory contains the Bats-based integration suite that exercises t
   - In non‑TTY, Bosun does not prompt; tests run with safe fallbacks.
 
 - Hanging or very slow tests
-  - Use timeouts: `TEST_TIMEOUT_SECS=180 BATS_FLAGS="--print-output-on-failure -T" make test`
+  - Opt into a timeout if needed: `TEST_TIMEOUT_SECS=180 BATS_FLAGS="--print-output-on-failure -T" make test`
   - Local sandbox (no network clones) is default: `SHIPLOG_USE_LOCAL_SANDBOX=1` (set to `0` only if required).
 
 - “Signing support not enabled” or skipped signing tests


### PR DESCRIPTION
## Summary
- add global \ plumbing and extend commands to honor it
- guard ref and note writes during dry runs and add reusable helpers
- make test timeouts opt-in and document the new behavior

## Testing
- make test