### PR TITLE
refactor: re-enable test timeout and polish dry-run

### DIFF
--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -55,6 +55,10 @@ See: docs/features/write.md for full semantics and examples.
 - `SHIPLOG_SETUP_AUTO_PUSH` — `1` to push policy/trust to origin
 - `SHIPLOG_SETUP_DRY_RUN` — `1` to preview without writing/syncing
 
+## Dry Run
+
+- `SHIPLOG_DRY_RUN` — Boolean/string flag (default `0`/`false`). When set to `1`, `true`, `yes`, or `on`, Shiplog enters dry-run mode: write/append/run/setup subcommands log intended actions without updating journals, notes, or pushing refs. Example: `export SHIPLOG_DRY_RUN=1` (bash/zsh) or `set -x SHIPLOG_DRY_RUN 1` (fish). Set `0`, `false`, `no`, or `off` to disable.
+
 ## Trust Bootstrap (non-interactive)
 
 - `SHIPLOG_TRUST_COUNT`, `SHIPLOG_TRUST_ID`, `SHIPLOG_TRUST_THRESHOLD`, `SHIPLOG_TRUST_COMMIT_MESSAGE`

--- a/test.sh
+++ b/test.sh
@@ -16,16 +16,16 @@ export PATH="$SHIPLOG_HOME/bin:$PATH"
 # Avoid network during tests by default; use local sandbox init
 export SHIPLOG_USE_LOCAL_SANDBOX="${SHIPLOG_USE_LOCAL_SANDBOX:-1}"
 
-# Optional timeout for the Bats test run (set TEST_TIMEOUT_SECS>0 to enable)
-TEST_TIMEOUT_SECS="${TEST_TIMEOUT_SECS:-}"
+# Enforce a timeout for the Bats test run (set TEST_TIMEOUT_SECS=0 to disable)
+TEST_TIMEOUT_SECS="${TEST_TIMEOUT_SECS:-180}"
 
 use_timeout() {
   local val="$1"
   case "$val" in
     ''|0|0s|0S|0sec|0SEC) return 1 ;;
-    *[!0-9]*) return 1 ;;
+    *[!0-9]*) return 2 ;;
   esac
-  [ "$val" -gt 0 ] 2>/dev/null
+  [ "$val" -gt 0 ]
 }
 
 if ! command -v bats >/dev/null 2>&1; then
@@ -33,13 +33,37 @@ if ! command -v bats >/dev/null 2>&1; then
   exit 127
 fi
 
-if command -v timeout >/dev/null 2>&1 && use_timeout "$TEST_TIMEOUT_SECS"; then
-  if [ -n "${BATS_FLAGS:-}" ]; then
-    timeout "${TEST_TIMEOUT_SECS}s" bats $BATS_FLAGS "$SHIPLOG_HOME/test"
+timeout_enabled=0
+use_timeout "$TEST_TIMEOUT_SECS"
+timeout_status=$?
+case "$timeout_status" in
+  0) timeout_enabled=1 ;;
+  1) timeout_enabled=0 ;;
+  2)
+    echo "shiplog test.sh: TEST_TIMEOUT_SECS must be a positive integer or 0 (got '${TEST_TIMEOUT_SECS}')" >&2
+    exit 64
+    ;;
+esac
+
+if command -v timeout >/dev/null 2>&1; then
+  if [ "$timeout_enabled" -eq 1 ]; then
+    if [ -n "${BATS_FLAGS:-}" ]; then
+      timeout "${TEST_TIMEOUT_SECS}s" bats $BATS_FLAGS "$SHIPLOG_HOME/test"
+    else
+      timeout "${TEST_TIMEOUT_SECS}s" bats -r "$SHIPLOG_HOME/test"
+    fi
   else
-    timeout "${TEST_TIMEOUT_SECS}s" bats -r "$SHIPLOG_HOME/test"
+    if [ -n "${BATS_FLAGS:-}" ]; then
+      bats $BATS_FLAGS "$SHIPLOG_HOME/test"
+    else
+      bats -r "$SHIPLOG_HOME/test"
+    fi
   fi
 else
+  if [ "$timeout_enabled" -eq 1 ]; then
+    echo "shiplog test.sh: timeout command not found but TEST_TIMEOUT_SECS=${TEST_TIMEOUT_SECS}; install coreutils timeout or set TEST_TIMEOUT_SECS=0" >&2
+    exit 64
+  fi
   if [ -n "${BATS_FLAGS:-}" ]; then
     bats $BATS_FLAGS "$SHIPLOG_HOME/test"
   else

--- a/test/02_write_and_ls_show.bats
+++ b/test/02_write_and_ls_show.bats
@@ -37,14 +37,20 @@ teardown() {
 }
 
 @test "write --dry-run previews without writing" {
-  run git show-ref "${REF_ROOT}/journal/prod"
+  local unique_env="prod-write-dryrun-${BATS_TEST_NUMBER:-0}-${RANDOM}${RANDOM}"
+  local journal_ref="${REF_ROOT}/journal/${unique_env}"
+  trap "git update-ref -d \"$journal_ref\" >/dev/null 2>&1 || true" EXIT
+
+  git update-ref -d "$journal_ref" >/dev/null 2>&1 || true
+
+  run git show-ref "$journal_ref"
   [ "$status" -ne 0 ]
 
-  run git shiplog --boring write --dry-run
+  run env SHIPLOG_ENV="$unique_env" git shiplog --boring write --dry-run
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Would sign & append entry to ${REF_ROOT}/journal/prod"* ]]
+  [[ "$output" == *"Would sign & append entry to ${REF_ROOT}/journal/${unique_env}"* ]]
 
-  run git show-ref "${REF_ROOT}/journal/prod"
+  run git show-ref "$journal_ref"
   [ "$status" -ne 0 ]
 }
 

--- a/test/10_run_command.bats
+++ b/test/10_run_command.bats
@@ -77,17 +77,23 @@ teardown() {
 }
 
 @test "run dry-run previews without executing" {
+  local unique_env="prod-run-dryrun-${BATS_TEST_NUMBER:-0}-${RANDOM}${RANDOM}"
+  local journal_ref="${REF_ROOT}/journal/${unique_env}"
+  trap "git update-ref -d \"$journal_ref\" >/dev/null 2>&1 || true" EXIT
+
+  git update-ref -d "$journal_ref" >/dev/null 2>&1 || true
+
   rm -f dry-run-file
   [ ! -e dry-run-file ]
 
-  run git show-ref "${REF_ROOT}/journal/prod"
+  run git show-ref "$journal_ref"
   [ "$status" -ne 0 ]
 
-  run bash -lc 'git shiplog run --dry-run --service test --reason "no-op" -- touch dry-run-file'
+  run bash -lc "SHIPLOG_ENV=\"$unique_env\" git shiplog run --dry-run --service test --reason 'no-op' -- touch dry-run-file"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Would execute: touch dry-run-file"* ]]
   [ ! -e dry-run-file ]
 
-  run git show-ref "${REF_ROOT}/journal/prod"
+  run git show-ref "$journal_ref"
   [ "$status" -ne 0 ]
 }

--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ The `test/` directory contains the Bats-based integration suite that exercises t
 - `make test` builds the local Docker image (if needed) and runs all Bats files with signing disabled. The container mounts the workspace at `/workspace` and executes `/usr/local/bin/run-tests`.
 - The `run-tests` entrypoint copies the repo to a temporary snapshot inside the container and sets `SHIPLOG_HOME` to that snapshot to prevent accidental mutations of the bind mount.
 - Default test mode avoids network clones: `SHIPLOG_USE_LOCAL_SANDBOX=1` (set to `0` only if you explicitly need to hit the remote sandbox).
-- You can opt into an in-container timeout by setting `TEST_TIMEOUT_SECS` to a positive integer. Add `BATS_FLAGS` (e.g., `--print-output-on-failure -T`) for verbose runs.
+- Tests run with an in-container timeout controlled by `TEST_TIMEOUT_SECS` (default `180`). Increase up to `360` when signing is enabled (`make test-signing`). Always capture container logs when a timeout occurs. Add `BATS_FLAGS` (e.g., `--print-output-on-failure -T`) for verbose runs.
 - `make test-signing` performs the same flow with `ENABLE_SIGNING=true`, generating a throw‑away GPG key inside the container to exercise signed‑commit verification.
 - The entrypoint installs `bin/git-shiplog` into `/usr/local/bin/git-shiplog` and exports `SHIPLOG_BOSUN_BIN`, then runs Bats (`bats -r`).
 - Each Bats file calls `load helpers/common`, whose `shiplog_install_cli` helper ensures the CLI is present and executable before tests begin.
@@ -47,7 +47,7 @@ The `test/` directory contains the Bats-based integration suite that exercises t
   - In non‑TTY, Bosun does not prompt; tests run with safe fallbacks.
 
 - Hanging or very slow tests
-  - Opt into a timeout if needed: `TEST_TIMEOUT_SECS=180 BATS_FLAGS="--print-output-on-failure -T" make test`
+  - Always run with the timeout guard: `TEST_TIMEOUT_SECS=180 BATS_FLAGS="--print-output-on-failure -T" make test` (raise to 360s when signing is enabled). Capture container logs if the timeout triggers.
   - Local sandbox (no network clones) is default: `SHIPLOG_USE_LOCAL_SANDBOX=1` (set to `0` only if required).
 
 - “Signing support not enabled” or skipped signing tests


### PR DESCRIPTION
## Summary
- restore the default 180s in-container timeout (with validation and erroring if timeout binary missing)
- tighten dry-run behavior: prevent remote syncs, escape structured logs, sanitize bosun tables, document env support
- update dry-run/timeout tests to use unique refs and self-clean setups

## Testing
- TEST_TIMEOUT_SECS=180 BATS_FLAGS="--print-output-on-failure -T" make test