### PR TITLE
Trust verifier (sig_mode), cleaner run output, publish command, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,16 @@
-# SHIPLOG • 🚢🪵
+## 🚢 Shiplog: Your Git Repo is an Ops Flight Recorder
 
-<p align="center">
-<img src="https://repository-images.githubusercontent.com/1060619650/5194fe70-a78c-4c2d-85d9-b43e8beb8717" width="600" />
-</p>
-
-## TL;DR Shiplog: Your Git Repo is an Ops Flight Recorder
-
-### Your Deployment History Should Live in Git
-
-**Shiplog**: your deployment history should live in the same repo as your code. No external services. No API keys. No monthly bills. Just git, doing what it does best: preserving history with cryptographic integrity.
-
-### Git: An Immutable, Distributed Journal
-
-***Git is a data structure.*** It can do way more than just source control. Shiplog's uses git to create chains of  commits that hang off of `refs/_shiplog/*` refs, creating an append-only journal. 
-
-### Don't Trust; Verify
-
-Shiplog uses a trust roster that's stored right in git, that restricts who may write to the journal, and uses a "policy by commits that require a quorum to change. that commit authors sign their commits to establish cryptographic provenance of each record, perfect for scenarios where you need immutable, auditable deployment and live-ops histories.
-
-### It's just Git.
-
-And best of all, it's all just git! You can fetch, push, clone, and verify using tools and knowledge you already have. No new software, no extra services. Just git.
+**TL;DR:** Your deployment history should live in the same repo as your code. No external services. No API keys. No monthly bills. Just **Git**, doing what it does best: preserving history with cryptographic integrity.
 
 ---
 
-## Friday, 3:17 PM
+## The Chaos Scenario: Friday, 3:17 PM
 
-*Bzzzt. Bzzzzzt. Bzzzzzzzzt.*
+*Bzzzt. Bzzzzzt. Bzzzzzzzzt.* The intern looks like they just saw a ghost. Dashboards flip from green to red. Slack explodes. Bob mutters, "It worked on my laptop."
 
-The intern looks like they just saw a ghost.
-The dashboards flip from green to red.  
-Slack explodes.  
-Bob mutters, “It worked on my laptop.”  
-The CI logs stop mid-sentence.  
-Jenkins, the poor old man, quietly running the same cron jobs since 2019, is suddenly a suspect. 
+You're about to dive into six different dashboards to piece together the truth when you remember: **We use Shiplog.**
 
-You’re about to dive into six different dashboards to piece together the truth when you remember: **We use Shiplog.**
-
-In a flash, you run a single command and the chaos dissolves. 
+In a flash, you run a single command and the chaos dissolves:
 
 ```bash
 git shiplog show
@@ -54,100 +27,34 @@ The truth is revealed: a failed migration, a clear timestamp, and the exact comm
 
 ## ✨ What Is Shiplog?
 
-Shiplog is your deployment black box recorder. Think `git commit` — but for releases. Every deployment leaves a cryptographically signed receipt in Git. Human-readable, machine-parseable, tamper-evident.
+Shiplog is your deployment **black box recorder**. Think `git commit`—but for every release and live-ops event. Every deployment leaves a cryptographically signed receipt in Git.
 
-Why you want it:
+### The Philosophy
 
-- 🧑‍💻 Readable: Debug at 3 a.m. without archeology.
-- 🤖 Parseable: Pipe JSON to dashboards, alerts, or bots.
-- 🔏 Signed: Clear provenance and compliance.
-- 🪢 Git-native: No infra. No SaaS. Just commits.
+Shiplog isn’t another deployment platform. It’s a **primitive**: a receipt, a ledger. Build your automated workflows around it, the same way you build around `git commit`.
 
-### 📦 Philosophy
+**Why you want it:**
 
-Shiplog isn’t another deployment platform.
-It’s a primitive. A receipt. A ledger.
-Build your workflows around it, same way you build around git commit.
+- 🧑‍💻 **Readable:** Debug deployments at 3 a.m. without archeology.
+- 🤖 **Parseable:** Pipe machine-readable JSON to dashboards, alerts, or bots.
+- 🔏 **Signed:** Clear provenance and compliance via commit signing.
+- 🪢 **Git-Native:** No infra. No SaaS. **Just Git commits.**
 
-No dashboards. No archaeology. Just clarity.
+### Git: An Immutable, Distributed Journal
 
----
-
-## 🚀 Getting Started
-
-```bash
-git clone https://github.com/flyingrobots/shiplog.git "$HOME/.shiplog"
-export SHIPLOG_HOME="$HOME/.shiplog"
-export PATH="$SHIPLOG_HOME/bin:$PATH"
-"$SHIPLOG_HOME/install-shiplog-deps.sh"
-```
-
-Verify install:
-
-```bash
-git shiplog --version
-```
+Git is a data structure. Shiplog uses it to create chains of commits that hang off of dedicated references (`refs/_shiplog/*`), forming an **append-only journal**. This is the core of its power—it can do way more than just source control.
 
 ---
 
-## 🛠️ Basic Usage
+## 🔐 Policy, Security, and Trust
 
-Initialize in your repo:
+**Don't Trust; Verify.** Shiplog establishes cryptographic provenance for every record and enforces policy _as code_, stored as a commit in your Git repository.
 
-```bash
-cd your-project
-git shiplog init
-```
+- **Trust Roster:** A list of approved authors is stored in Git, restricting who may write to the journal.
+- **Policy by Quorum:** Policies themselves require a quorum of authorized signers to change.
+- **Cryptographic Provenance:** Commit authors **sign their commits** to establish who created each record, perfect for auditable histories.
 
-*(NOTE: See [docs/TRUST.md](docs/TRUST.md) for one-time policy and trust setup instructions)*
-
-Record a deployment event:
-
-```bash
-export SHIPLOG_ENV=prod
-export SHIPLOG_SERVICE=web
-git shiplog write
-```
-
-Inspect history:
-
-```bash
-git shiplog ls --env prod
-git shiplog show --json
-```
-
-Pipe to tools:
-
-```bash
-git shiplog export-json | jq .
-```
-
-Wrap a command and capture its output automatically:
-
-```bash
-git shiplog run --service deploy --reason "Canary" -- env kubectl rollout status deploy/web
-```
-
-Append structured data non-interactively (great for automation):
-
-```bash
-printf '{"checks": {"canary": "green"}}' | \
-  git shiplog append --env prod --region us-west-2 --cluster prod-a \
-    --namespace frontend --service deploy --status success \
-    --reason "post-release smoke" --json -
-```
-
----
-
-## 🔐 Policy & Security
-
-Shiplog enforces policy as code, stored in Git itself.
-
-- `refs/_shiplog/journal/<env>` → append-only logs
-- `refs/_shiplog/policy/current` → signed policy refs
-- Optional strict mode: signed commits per-env (e.g., prod only)
-
-### Example policy (`.shiplog/policy.json`)
+### Example Policy (`.shiplog/policy.json`)
 
 ```json
 {
@@ -161,28 +68,92 @@ Shiplog enforces policy as code, stored in Git itself.
 }
 ```
 
+- `refs/_shiplog/journal/<env>` → Append-only logs for each environment.
+- `refs/_shiplog/policy/current` → Signed policy references.
+
+---
+
+## 🚀 Getting Started
+
+It's all just Git! You can fetch, push, clone, and verify using tools and knowledge you already have.
+
+### Installation
+
+```bash
+git clone https://github.com/flyingrobots/shiplog.git "$HOME/.shiplog"
+export SHIPLOG_HOME="$HOME/.shiplog"
+export PATH="$SHIPLOG_HOME/bin:$PATH"
+"$SHIPLOG_HOME/install-shiplog-deps.sh"
+```
+
+**Verify install:**
+
+```bash
+git shiplog --version
+```
+
+### Basic Usage
+
+1. Initialize Shiplog in your repository:
+
+```bash
+cd your-project
+git shiplog init
+```
+
+_(NOTE: See [`docs/TRUST.md`](docs/TRUST.md) for one-time policy and trust setup instructions)_
+   
+2. Record a deployment event:
+
+```bash
+export SHIPLOG_ENV=prod
+export SHIPLOG_SERVICE=web
+git shiplog write
+```
+ 
+3. Inspect history:
+
+```bash
+git shiplog ls --env prod
+git shiplog show --json
+```
+   
+4. Wrap a command and capture its output automatically:
+
+```bash
+git shiplog run --service deploy --reason "Canary" -- env kubectl rollout status deploy/web
+```
+ 
+5. Append structured data non-interactively (great for automation):
+
+```bash
+printf '{"checks": {"canary": "green"}}' | \
+  git shiplog append --env prod --region us-west-2 --cluster prod-a \
+	--namespace frontend --service deploy --status success \
+	--reason "post-release smoke" --json -
+``` 
+
 ---
 
 ## ⚙️ Core Commands
 
-| Command |	Purpose |
-|---------|---------|
-| `git shiplog init` |	Setup refs & configs |
-| `git shiplog write` |	Record a deployment |
-| `git shiplog append` |	Record a deployment via JSON payload (stdin or file) |
-| `git shiplog run` |	Wrap a command, capture logs, and record result |
-| `git shiplog ls` |	List recent entries |
-| `git shiplog show` |	Show entry details |
-| `git shiplog trust show` |	Display trust roster and signer inventory |
-| `git shiplog verify` |	Verify signatures/allowlist |
-| `git shiplog export-json` |	Export NDJSON for tools |
+|Command|Purpose|
+|---|---|
+|`git shiplog init`|Setup references (`refs`) and configuration.|
+|`git shiplog write`|Record a deployment interactively.|
+|`git shiplog append`|Record a deployment via JSON payload (stdin or file).|
+|`git shiplog run`|Wrap a command, capture logs, and record the result.|
+|`git shiplog ls`|List recent entries.|
+|`git shiplog show`|Show entry details.|
+|`git shiplog trust show`|Display trust roster and signer inventory.|
+|`git shiplog verify`|Verify signatures and policy compliance.|
+|`git shiplog export-json`|Export NDJSON for tools.|
 
 ---
 
 ## 🧪 Testing
 
-> [!WARNING]
-> ⚠️ **Shiplog developers**: Avoid running Shiplog in its own repo path. Shiplog mutates Git refs! By default, tests are configured to run in a Docker container. Use it!
+> ⚠️ **Warning to Shiplog Developers:** Avoid running Shiplog in its own repository path. Shiplog mutates Git refs! By default, tests are configured to run in a Docker container. Use it!
 
 ```bash
 make test         # Unsigned, fast
@@ -193,6 +164,6 @@ make test-signing # With loopback GPG key
 
 ## 📜 License
 
-MIT © J. Kirby Ross • @flyingrobots
+MIT © J. Kirby Ross • [@flyingrobots](https://github.com/flyingrobots)
 
-*Jenkins was not harmed in the making of this project.*
+_Jenkins was not harmed in the making of this project._

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -60,6 +60,21 @@ SHIPLOG_TRUST_SIG_MODE=attestation git shiplog setup
 2) Add the “Shiplog Trust Verify” workflow as a Required Status Check on `_shiplog/**`.
 3) If `threshold>1`, pick a `sig_mode` and follow the pattern for co‑signing or attaching signatures in PRs.
 
+### Optional: Disable Auto‑Push During Deploys
+
+- Some teams prefer not to push during the deploy (pre‑push hooks can be disruptive). You can disable auto‑push and publish at the end:
+
+```
+git config shiplog.autoPush false   # per repo default
+# during the deploy
+git shiplog run ...                 # records locally
+# after success
+git shiplog publish                 # push journals/notes to origin
+```
+
+- Flags still override the default: `--push` or `--no-push`.
+- CI can keep auto‑push on (set `shiplog.autoPush true` or pass `--push`).
+
 ## Compatibility
 
 - If `sig_mode` is missing in `trust.json`, verification defaults to `chain` and still requires the trust commit to be signature‑verified.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,83 @@
+# Shiplog — Next Release (Unreleased)
+
+This note summarizes what’s changing, what you need to do (by scenario), SaaS vs self‑hosted enforcement guidance, and UX improvements requested by early adopters.
+
+## Highlights
+
+- Trust quorum modes (sig_mode): choose between `chain` (co‑sign commits) or `attestation` (detached signature files) to meet `threshold` maintainer signatures.
+- Unified trust verifier: a single script validates trust updates for hooks and CI.
+- SaaS‑friendly enforcement: example GitHub workflow added to make trust checks a Required Status Check on `_shiplog/**`.
+- Cleaner CLI output: `git shiplog run` now streams the wrapped command output and prints a short success line instead of a full entry preview.
+- Friendlier headers/tables: optional fields are hidden in human headers; `ls` avoids noisy `?` placeholders.
+
+## What’s New
+
+### 1) Trust Signing Modes
+
+- New field in `.shiplog/trust.json`:
+  - `"sig_mode": "chain" | "attestation"`
+- `chain` (co‑sign chain): each maintainer signs the same trust tree by adding a commit over that tree; threshold is met when ≥ `threshold` distinct maintainer‑signed commits are present in a fast‑forward update.
+- `attestation` (detached sigs): keep one trust commit; store ≥ `threshold` signature files under `.shiplog/trust_sigs/` that sign the trust tree OID.
+
+Choosing the mode:
+
+```bash
+# Interactive bootstrap will prompt; defaults to chain
+./scripts/shiplog-bootstrap-trust.sh --trust-sig-mode chain   # or attestation
+
+# Non-interactive
+SHIPLOG_TRUST_SIG_MODE=attestation git shiplog setup
+```
+
+### 2) Verification (Hooks and SaaS)
+
+- New: `scripts/shiplog-verify-trust.sh` — shared verifier used by both server hooks and CI.
+- Pre‑receive hook now calls the verifier when present (self‑hosted). Fallback still requires a valid signature and blocks `threshold>1` without an env escape hatch.
+- SaaS (GitHub.com et al.): example workflow at `docs/examples/github/workflow-shiplog-trust-verify.yml` you can mark as a Required Status Check for `_shiplog/**`.
+
+### 3) Cleaner Output
+
+- `git shiplog run` no longer prints the full entry preview. It streams the wrapped command, then prints a one‑liner like `Recorded to Shiplog [abcd123]`.
+- Human headers now hide missing location parts. If you only have `env=prod`, headers render `→ prod` (no `?/?/?`).
+- `git shiplog ls` reads env/service/status from JSON (when jq is available) and prints `-` for missing values instead of `?`.
+
+## What You Need To Do
+
+> TL;DR: update scripts and hooks; pick a mode only if you’ll use `threshold>1`; add a Required Check on SaaS.
+
+### Self‑Hosted (GitHub Enterprise, GitLab self‑managed, Gitea, Bitbucket DC)
+
+1) Update the server’s hook and scripts:
+   - Install `contrib/hooks/pre-receive.shiplog` (replace the previous version).
+   - Ensure `scripts/shiplog-verify-trust.sh` is in the repo alongside the hook.
+2) If `threshold==1` today, you’re done. If `threshold>1` or will be:
+   - Choose a `sig_mode` (`chain` or `attestation`) and create the next trust update accordingly.
+3) Optional: re‑run `./scripts/shiplog-trust-sync.sh` on workstations/CI to refresh `gpg.ssh.allowedSignersFile`.
+
+### SaaS (GitHub.com, GitLab SaaS, Bitbucket Cloud)
+
+1) Use branch namespace for Shiplog refs (`refs/heads/_shiplog/**`) and protect it (no deletions, no force‑push, require PRs).
+2) Add the “Shiplog Trust Verify” workflow as a Required Status Check on `_shiplog/**`.
+3) If `threshold>1`, pick a `sig_mode` and follow the pattern for co‑signing or attaching signatures in PRs.
+
+## Compatibility
+
+- If `sig_mode` is missing in `trust.json`, verification defaults to `chain` and still requires the trust commit to be signature‑verified.
+- No journal/history rewrites are needed. Existing entries remain valid.
+
+## Migration Notes (Threshold > 1)
+
+- Chain mode (recommended for self‑hosted): PR with ≥ `threshold` signer commits over the same trust tree; merge fast‑forward.
+- Attestation mode (recommended for SaaS): PR adds ≥ `threshold` `.sig` files under `.shiplog/trust_sigs/` that sign the trust tree OID; squash to a single trust commit; Required Check verifies them.
+- Temporary escape hatch for staged rollouts (self‑hosted only): set `SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED=1` for the Git server user; remove ASAP.
+
+## UX Changes in CLI
+
+- `shiplog run` now prints a concise confirmation line. It still returns the wrapped command’s exit code and attaches logs as notes when non‑empty.
+- Human headers hide absent fields; no more `?` placeholders. Tables prefer `-` when a value is missing.
+
+## Known Follow‑ups
+
+- Attestation signature verification: a small helper will be added to emit and verify SSH signatures over a canonical payload (tree OID + context). The verifier will then enforce validity (not just presence) for `.sig` files.
+- Hosting matrix doc: guidance for GitHub/GitLab/Bitbucket/Gitea with prescriptive protection settings and Required Checks.
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ This note summarizes what’s changing, what you need to do (by scenario), SaaS 
 - Trust quorum modes (sig_mode): choose between `chain` (co‑sign commits) or `attestation` (detached signature files) to meet `threshold` maintainer signatures.
 - Unified trust verifier: a single script validates trust updates for hooks and CI.
 - SaaS‑friendly enforcement: example GitHub workflow added to make trust checks a Required Status Check on `_shiplog/**`.
-- Cleaner CLI output: `git shiplog run` now streams the wrapped command output and prints a short success line instead of a full entry preview.
+- Cleaner CLI output: `git shiplog run` now streams the wrapped command output and prints a minimal confirmation (default `🪵`) instead of a full entry preview; override via `SHIPLOG_CONFIRM_TEXT`.
 - Friendlier headers/tables: optional fields are hidden in human headers; `ls` avoids noisy `?` placeholders.
 
 ## What’s New
@@ -37,7 +37,7 @@ SHIPLOG_TRUST_SIG_MODE=attestation git shiplog setup
 
 ### 3) Cleaner Output
 
-- `git shiplog run` no longer prints the full entry preview. It streams the wrapped command, then prints a one‑liner like `Recorded to Shiplog [abcd123]`.
+- `git shiplog run` no longer prints the full entry preview. It streams the wrapped command, then prints a minimal confirmation (default `🪵`; override with `SHIPLOG_CONFIRM_TEXT`).
 - Human headers now hide missing location parts. If you only have `env=prod`, headers render `→ prod` (no `?/?/?`).
 - `git shiplog ls` reads env/service/status from JSON (when jq is available) and prints `-` for missing values instead of `?`.
 
@@ -80,4 +80,3 @@ SHIPLOG_TRUST_SIG_MODE=attestation git shiplog setup
 
 - Attestation signature verification: a small helper will be added to emit and verify SSH signatures over a canonical payload (tree OID + context). The verifier will then enforce validity (not just presence) for `.sig` files.
 - Hosting matrix doc: guidance for GitHub/GitLab/Bitbucket/Gitea with prescriptive protection settings and Required Checks.
-

--- a/bin/git-shiplog
+++ b/bin/git-shiplog
@@ -14,6 +14,7 @@ AUTHOR_ALLOWLIST="${SHIPLOG_AUTHORS:-}"
 ALLOWED_SIGNERS_FILE="${SHIPLOG_ALLOWED_SIGNERS:-.shiplog/allowed_signers}"
 SHIPLOG_BORING="${SHIPLOG_BORING:-0}"
 SHIPLOG_AUTO_PUSH="${SHIPLOG_AUTO_PUSH:-1}"
+SHIPLOG_AUTO_PUSH_FLAG="${SHIPLOG_AUTO_PUSH_FLAG:-0}"
 export SHIPLOG_BORING
 export SHIPLOG_AUTO_PUSH
 
@@ -96,12 +97,16 @@ run_with_global_flags() {
         ;;
       --no-push)
         SHIPLOG_AUTO_PUSH=0
+        SHIPLOG_AUTO_PUSH_FLAG=1
         export SHIPLOG_AUTO_PUSH
+        export SHIPLOG_AUTO_PUSH_FLAG
         shift
         ;;
       --push)
         SHIPLOG_AUTO_PUSH=1
+        SHIPLOG_AUTO_PUSH_FLAG=1
         export SHIPLOG_AUTO_PUSH
+        export SHIPLOG_AUTO_PUSH_FLAG
         shift
         ;;
       --version|-V)

--- a/contrib/hooks/pre-receive.shiplog
+++ b/contrib/hooks/pre-receive.shiplog
@@ -108,12 +108,49 @@ validate_trust_update() {
   local old="$1" new="$2"
   ensure_fast_forward "$old" "$new" "$TRUST_REF"
   load_trust_state "$new"
+  enforce_trust_threshold "$new"
 }
 
 validate_policy_update() {
   local old="$1" new="$2"
   ensure_fast_forward "$old" "$new" "$POLICY_REF"
-  load_policy_state "$new"
+load_policy_state "$new"
+}
+
+# Enforce that the new trust commit is properly signed and (eventually) co-signed
+enforce_trust_threshold() {
+  local commit="$1"
+  # Require a valid signature on the trust commit itself (threshold >= 1)
+  if [ -n "$SIGNERS_FILE" ]; then
+    if ! GIT_SSH_ALLOWED_SIGNERS="$SIGNERS_FILE" git verify-commit "$commit" >/dev/null 2>&1; then
+      error "trust commit $commit has missing or invalid signature"
+    fi
+  else
+    # Fall back to generic verification if signers file is absent (PGP or globally configured)
+    if ! git verify-commit "$commit" >/dev/null 2>&1; then
+      error "trust commit $commit failed signature verification"
+    fi
+  fi
+
+  # Enforce threshold semantics progressively.
+  # NOTE: Git commits carry a single embedded signature. Multi-maintainer co-signing requires a
+  # higher-level pattern (e.g., a linear chain of N commits over the same tree, or detached
+  # attestations stored in the trust tree). Until that is implemented, we fail closed by default
+  # when threshold > 1, with an escape hatch for staged rollouts.
+  local threshold
+  threshold=$(printf '%s' "$CURRENT_TRUST_JSON" | "$JQ_BIN" -r '.threshold // 1')
+  case "$threshold" in
+    ''|null) threshold=1 ;;
+  esac
+  if ! printf '%s' "$threshold" | grep -Eq '^[1-9][0-9]*$'; then
+    error "trust.json invalid threshold value: $threshold"
+  fi
+
+  if [ "$threshold" -gt 1 ]; then
+    if [ "${SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED:-0}" != "1" ]; then
+      error "trust threshold $threshold not yet enforced by hook; set SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED=1 to allow temporarily"
+    fi
+  fi
 }
 
 read_commit_json() {

--- a/contrib/hooks/pre-receive.shiplog
+++ b/contrib/hooks/pre-receive.shiplog
@@ -108,7 +108,13 @@ validate_trust_update() {
   local old="$1" new="$2"
   ensure_fast_forward "$old" "$new" "$TRUST_REF"
   load_trust_state "$new"
-  enforce_trust_threshold "$new"
+  # Run shared verifier if available (preferred for both modes)
+  if [ -x "$GIT_DIR/../scripts/shiplog-verify-trust.sh" ]; then
+    (cd "$GIT_DIR/.." && ./scripts/shiplog-verify-trust.sh --old "$old" --new "$new" --ref "$TRUST_REF") || error "trust verification failed"
+  else
+    # Fallback: require at least one valid signature and block threshold>1 by default
+    enforce_trust_threshold "$new"
+  fi
 }
 
 validate_policy_update() {

--- a/docs/examples/github/workflow-shiplog-trust-verify.yml
+++ b/docs/examples/github/workflow-shiplog-trust-verify.yml
@@ -1,0 +1,48 @@
+name: Shiplog Trust Verify
+
+on:
+  pull_request:
+    paths:
+      - '_shiplog/**'
+      - '.github/workflows/workflow-shiplog-trust-verify.yml'
+  push:
+    branches:
+      - _shiplog/**
+
+permissions:
+  contents: read
+
+jobs:
+  verify-trust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Verify trust update
+        env:
+          SHIPLOG_JQ_BIN: jq
+          # Allow temporarily while migrating (set to 0 to enforce):
+          SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED: 0
+        run: |
+          set -euo pipefail
+          if [ -x scripts/shiplog-verify-trust.sh ]; then
+            # Determine old..new range for trust ref when on PRs
+            ref="refs/heads/_shiplog/trust/root"
+            git fetch origin "+$ref:$ref" || true
+            new=$(git rev-parse -q --verify "$ref" || true)
+            base="0000000000000000000000000000000000000000"
+            if [ -n "$GITHUB_BASE_REF" ]; then
+              # Best-effort: use merge-base between PR base and current trust ref
+              if git show-ref --verify --quiet "refs/remotes/origin/$GITHUB_BASE_REF"; then
+                base=$(git merge-base "refs/remotes/origin/$GITHUB_BASE_REF" "$ref" || echo "$base")
+              fi
+            fi
+            ./scripts/shiplog-verify-trust.sh --old "$base" --new "$new" --ref "$ref"
+          else
+            echo "scripts/shiplog-verify-trust.sh not found; please add it to your repository" >&2
+            exit 1
+          fi
+

--- a/docs/examples/github/workflow-shiplog-trust-verify.yml
+++ b/docs/examples/github/workflow-shiplog-trust-verify.yml
@@ -1,6 +1,6 @@
 name: Shiplog Trust Verify
 
-on:
+"on":
   pull_request:
     paths:
       - '_shiplog/**'
@@ -45,4 +45,3 @@ jobs:
             echo "scripts/shiplog-verify-trust.sh not found; please add it to your repository" >&2
             exit 1
           fi
-

--- a/docs/features/command-reference.md
+++ b/docs/features/command-reference.md
@@ -44,7 +44,7 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
     - Success case: `git shiplog run --service deploy --reason "Smoke test" -- env printf hi`
     - Failure case: `git shiplog run --service deploy --status-failure failed -- false`
   - Flags: `--service`, `--reason`, `--status-success`, `--status-failure`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--env`, `--dry-run`.
-  - Notes: captures stdout/stderr to a temporary log that is attached as a git note (skipped if empty) and merges `{run:{...}}` into the JSON trailer via `SHIPLOG_EXTRA_JSON`. `--dry-run` prints the command that would execute and exits without running it or writing a journal entry. See `docs/features/run.md` for detailed behavior (preview output, exit codes, caveats) and `docs/reference/json-schema.md` for the structured payload.
+  - Notes: captures stdout/stderr to a temporary log that is attached as a git note (skipped if empty) and merges `{run:{...}}` into the JSON trailer via `SHIPLOG_EXTRA_JSON`. Prints a minimal confirmation after the run (default `🪵`), configurable via `SHIPLOG_CONFIRM_TEXT`. `--dry-run` prints the command that would execute and exits without running it or writing a journal entry. See `docs/features/run.md` for details.
 
 - `ls [ENV] [LIMIT]`
   - Purpose: list recent entries.

--- a/docs/features/command-reference.md
+++ b/docs/features/command-reference.md
@@ -74,6 +74,11 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
   - Usage: `git shiplog export-json prod | jq '.'`
   - Requires: `jq`.
 
+- `publish [ENV] [--no-notes] [--policy] [--trust] [--all]`
+  - Purpose: push Shiplog refs (journals/notes, and optionally policy/trust) to origin without writing a new entry.
+  - Usage: `git shiplog publish` (current env), `git shiplog publish --env prod`, `git shiplog publish --all --policy`
+  - Notes: use this at the end of a deployment if you disable auto-push.
+
 - `policy [show|validate|require-signed|toggle] [--json] [--boring]`
   - Purpose: inspect/change effective policy and signing requirement.
   - Usage:

--- a/docs/features/ls.md
+++ b/docs/features/ls.md
@@ -30,11 +30,9 @@ git shiplog --env staging ls
   3. `SHIPLOG_ENV` environment variable
   4. Falls back to default (`prod`) if none specified
 - **Journal Reference**: Lists from `refs/_shiplog/journal/<env>`. If the ref has no entries, the command fails with an error.
-- **Entry Processing**: Extracts the following metadata from each journal commit:
-  - Status (deployed/failed/etc.)
-  - Service name
-  - Author information
-  - Timestamp
+- **Entry Processing**: When `jq` is available, `ls` reads values from the JSON trailer for robustness. Otherwise it falls back to subject/body parsing.
+- **Columns**: Status, Service, Env, Author, Date.
+- **Missing values**: Rendered as `-` (columns are kept stable; no noisy `?`).
 - **LIMIT**: Caps the number of entries returned (default `20`).
 - **Output**: In interactive mode with Bosun, renders a table. Otherwise prints TSV with header.
 

--- a/docs/features/run.md
+++ b/docs/features/run.md
@@ -23,7 +23,7 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 - Deterministic output keeps automation safe while rehearsing deploy playbooks.
 
 ## Behavior (Standard Runs)
-- Captures stdout/stderr to a temporary file. When Bosun is available, output streams through a live preview while still being recorded for notes.
+- Captures stdout/stderr to a temporary file. When Bosun is available, output streams live while still being recorded for notes.
 - Sets `SHIPLOG_BORING=1` and `SHIPLOG_ASSUME_YES=1` while delegating to `git shiplog write`, ensuring prompts are bypassed.
 - Populates `SHIPLOG_EXTRA_JSON` with a `run` block such as:
   ```json
@@ -43,6 +43,13 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 - Attaches the captured log as a git note under `refs/_shiplog/notes/logs` when an entry is written successfully.
 - Returns the wrapped command’s exit code so it can chain cleanly in scripts or CI pipelines.
 
+### Confirmation Output
+
+- After the wrapped command completes, Shiplog prints a minimal confirmation line.
+- Default: a log emoji only (`🪵`).
+- Customize with `SHIPLOG_CONFIRM_TEXT` (e.g., `> Shiplogged`, `Recorded`).
+- The previous verbose preview is suppressed to keep terminals quiet; use `git shiplog show` if you want to inspect the entry that was written.
+
 ## Exit Codes
 - Dry run
   - `0` when the preview succeeds.
@@ -60,6 +67,7 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 - `--status-failure <status>` — Status recorded when the command fails. Default `failed`.
 - `--ticket <id>`, `--region <r>`, `--cluster <c>`, `--namespace <ns>` — Override standard write metadata.
 - When there is no output, log attachment is skipped and `log_attached=false` is recorded in the trailer.
+ - Confirmation text: set `SHIPLOG_CONFIRM_TEXT` to override the default emoji (see above).
 
 ## Caveats
 - Dry runs do not validate connectivity to downstream systems—it only checks CLI argument parsing and policy prerequisites.

--- a/docs/features/setup.md
+++ b/docs/features/setup.md
@@ -28,7 +28,7 @@ When bootstrapping trust, you can pick how quorum signatures are recorded and ve
 
 Set explicitly via flags or env during setup/bootstrap:
 
-```
+```bash
 git shiplog setup --trust-sig-mode chain   # or attestation
 SHIPLOG_TRUST_SIG_MODE=attestation git shiplog setup
 ```

--- a/docs/features/setup.md
+++ b/docs/features/setup.md
@@ -19,6 +19,22 @@ SHIPLOG_SETUP_AUTHORS="you@example.com teammate@example.com" \
 SHIPLOG_SETUP_AUTO_PUSH=1 \
   git shiplog setup
 
+### Choose a Trust Signing Mode (chain vs attestation)
+
+When bootstrapping trust, you can pick how quorum signatures are recorded and verified:
+
+- `chain` — co‑sign chain of commits (pure Git; great with server hooks)
+- `attestation` — detached signatures stored under `.shiplog/trust_sigs/` (great for PRs on SaaS hosts)
+
+Set explicitly via flags or env during setup/bootstrap:
+
+```
+git shiplog setup --trust-sig-mode chain   # or attestation
+SHIPLOG_TRUST_SIG_MODE=attestation git shiplog setup
+```
+
+See docs/TRUST.md for details and a comparison.
+
 ## Modes
 
 - Open (unsigned):
@@ -33,6 +49,7 @@ SHIPLOG_SETUP_AUTO_PUSH=1 \
   - Global strict: `require_signed=true` for all environments.
   - Per‑environment strict: `require_signed=false` globally and `deployment_requirements.<env>.require_signed=true` for selected envs (e.g., prod only).
   - Non‑interactive trust bootstrap supported via `SHIPLOG_TRUST_*` env vars (see docs/features/modes.md). The wizard runs the bootstrap script and can auto‑push the trust ref with `--auto-push`.
+  - Signing mode: pass `--trust-sig-mode chain|attestation` (default `chain`).
 
 ## CLI Trust Bootstrap (No Prompts)
 

--- a/docs/features/write.md
+++ b/docs/features/write.md
@@ -20,6 +20,7 @@ SHIPLOG_BORING=1 git shiplog --yes write prod --service release --reason "MVP re
 - Prompts for service, status, change details, and artifact information. You can prefill or bypass prompts with flags (`--service`, `--reason`, etc.) or environment variables listed below.
 - Defaults the namespace to the journal environment when left blank (e.g., `prod`).
 - Generates both a human-readable header and a JSON trailer; optionally attaches NDJSON logs via `SHIPLOG_LOG`.
+- Human-readable header hides missing location parts: if you only provide `env=prod`, it renders `→ prod` (no placeholders for region/cluster/namespace).
 - Accepts `--yes` to skip confirmation prompts (sets `SHIPLOG_ASSUME_YES=1`).
 - Fast-forwards the journal ref; aborts if the ref is missing or would require a force update.
 - Automatically pushes the updated journal (and attached notes) to `origin` when available; disable with `SHIPLOG_AUTO_PUSH=0` or `--no-push`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,668 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shiplog: Git-Native Deployment Journal</title>
+    <meta name="description" content="Auditable deployment logs that live in your git repo. Cryptographically signed, append-only, and offline-capable. No SaaS, no external services, just git.">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Space+Mono&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --color-primary: #34495e;
+            --color-secondary: #e74c3c;
+            --color-light: #ecf0f1;
+            --color-accent: #2ecc71;
+            --color-warning: #f39c12;
+            --font-main: 'Roboto', sans-serif;
+            --font-code: 'Space Mono', monospace;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: var(--font-main);
+            color: var(--color-primary);
+            margin: 0;
+            padding: 0;
+            background-color: var(--color-light);
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        
+        /* Hero Section - The Pain */
+        .hero {
+            background: linear-gradient(135deg, #34495e 0%, #2c3e50 100%);
+            color: white;
+            padding: 60px 20px;
+            text-align: center;
+        }
+        .hero h1 {
+            font-size: 2.8em;
+            margin: 0 0 20px 0;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+        .hero .subtitle {
+            font-size: 1.4em;
+            opacity: 0.95;
+            max-width: 800px;
+            margin: 0 auto 30px auto;
+            font-weight: 300;
+        }
+        .hero .problem {
+            background-color: rgba(231, 76, 60, 0.2);
+            border-left: 4px solid var(--color-secondary);
+            padding: 20px;
+            margin: 30px auto;
+            max-width: 700px;
+            text-align: left;
+            border-radius: 4px;
+        }
+        .hero .problem p {
+            margin: 0;
+            font-size: 1.1em;
+            line-height: 1.6;
+        }
+        
+        /* CTA Buttons */
+        .cta-primary {
+            display: inline-block;
+            margin: 10px;
+            padding: 15px 35px;
+            background-color: var(--color-accent);
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: 700;
+            font-size: 1.1em;
+            transition: all 0.3s;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+        }
+        .cta-primary:hover {
+            background-color: #27ae60;
+            transform: translateY(-2px);
+            box-shadow: 0 6px 12px rgba(0,0,0,0.3);
+        }
+        .cta-secondary {
+            display: inline-block;
+            margin: 10px;
+            padding: 15px 35px;
+            background-color: transparent;
+            color: white;
+            text-decoration: none;
+            border: 2px solid white;
+            border-radius: 5px;
+            font-weight: 700;
+            font-size: 1.1em;
+            transition: all 0.3s;
+        }
+        .cta-secondary:hover {
+            background-color: rgba(255,255,255,0.1);
+        }
+        
+        /* The Solution */
+        .solution {
+            background-color: white;
+            padding: 50px 20px;
+            border-bottom: 3px solid var(--color-accent);
+        }
+        .solution h2 {
+            text-align: center;
+            font-size: 2.2em;
+            margin-bottom: 15px;
+            color: var(--color-primary);
+        }
+        .solution .tagline {
+            text-align: center;
+            font-size: 1.3em;
+            color: #7f8c8d;
+            margin-bottom: 40px;
+        }
+        
+        /* Code Blocks */
+        .code-block {
+            background-color: #2c3e50;
+            color: #ecf0f1;
+            font-family: var(--font-code);
+            padding: 25px;
+            border-radius: 8px;
+            margin: 25px 0;
+            overflow-x: auto;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+        }
+        .code-block pre {
+            margin: 0;
+            white-space: pre;
+            line-height: 1.5;
+        }
+        .code-comment {
+            color: #95a5a6;
+            font-style: italic;
+        }
+        .code-prompt {
+            color: var(--color-accent);
+            user-select: none;
+        }
+        .code-output {
+            color: #3498db;
+        }
+        
+        /* Feature Grid */
+        .features {
+            padding: 60px 20px;
+            background-color: var(--color-light);
+        }
+        .features h2 {
+            text-align: center;
+            font-size: 2.2em;
+            margin-bottom: 50px;
+            color: var(--color-primary);
+        }
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 30px;
+            margin-bottom: 40px;
+        }
+        .feature-card {
+            background: white;
+            padding: 35px;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+            transition: transform 0.3s, box-shadow 0.3s;
+        }
+        .feature-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 12px rgba(0,0,0,0.1);
+        }
+        .feature-icon {
+            font-size: 3.5em;
+            margin-bottom: 15px;
+            display: block;
+        }
+        .feature-card h3 {
+            color: var(--color-primary);
+            margin: 0 0 15px 0;
+            font-size: 1.4em;
+        }
+        .feature-card p {
+            margin: 0;
+            color: #7f8c8d;
+            line-height: 1.7;
+        }
+        
+        /* How It Works */
+        .how-it-works {
+            padding: 60px 20px;
+            background-color: white;
+        }
+        .how-it-works h2 {
+            text-align: center;
+            font-size: 2.2em;
+            margin-bottom: 20px;
+            color: var(--color-primary);
+        }
+        .how-it-works .intro {
+            text-align: center;
+            font-size: 1.2em;
+            color: #7f8c8d;
+            margin-bottom: 50px;
+            max-width: 700px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .demo-section {
+            margin: 50px 0;
+        }
+        .demo-section h3 {
+            font-size: 1.6em;
+            color: var(--color-secondary);
+            margin-bottom: 15px;
+            border-left: 5px solid var(--color-secondary);
+            padding-left: 15px;
+        }
+        .demo-section p {
+            font-size: 1.1em;
+            color: #555;
+            margin-bottom: 20px;
+        }
+        
+        /* Installation */
+        .installation {
+            padding: 60px 20px;
+            background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+            color: white;
+        }
+        .installation h2 {
+            text-align: center;
+            font-size: 2.2em;
+            margin-bottom: 20px;
+        }
+        .installation .intro {
+            text-align: center;
+            font-size: 1.2em;
+            margin-bottom: 40px;
+            opacity: 0.9;
+        }
+        .install-steps {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .install-step {
+            margin-bottom: 30px;
+        }
+        .install-step h4 {
+            font-size: 1.3em;
+            margin-bottom: 10px;
+            color: var(--color-accent);
+        }
+        
+        /* Use Cases */
+        .use-cases {
+            padding: 60px 20px;
+            background-color: var(--color-light);
+        }
+        .use-cases h2 {
+            text-align: center;
+            font-size: 2.2em;
+            margin-bottom: 50px;
+            color: var(--color-primary);
+        }
+        .use-case-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 25px;
+        }
+        .use-case {
+            background: white;
+            padding: 25px;
+            border-radius: 8px;
+            border-left: 4px solid var(--color-accent);
+        }
+        .use-case h4 {
+            margin-top: 0;
+            color: var(--color-primary);
+            font-size: 1.2em;
+        }
+        .use-case ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .use-case li {
+            margin-bottom: 8px;
+            color: #555;
+        }
+        
+        /* FAQ */
+        .faq {
+            padding: 60px 20px;
+            background-color: white;
+        }
+        .faq h2 {
+            text-align: center;
+            font-size: 2.2em;
+            margin-bottom: 50px;
+            color: var(--color-primary);
+        }
+        .faq-item {
+            max-width: 800px;
+            margin: 0 auto 30px auto;
+            padding: 25px;
+            background-color: var(--color-light);
+            border-radius: 8px;
+        }
+        .faq-item h4 {
+            margin-top: 0;
+            color: var(--color-secondary);
+            font-size: 1.3em;
+        }
+        .faq-item p {
+            margin-bottom: 0;
+            color: #555;
+            line-height: 1.7;
+        }
+        
+        /* Footer CTA */
+        .footer-cta {
+            background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+            color: white;
+            padding: 60px 20px;
+            text-align: center;
+        }
+        .footer-cta h2 {
+            font-size: 2.5em;
+            margin-bottom: 20px;
+        }
+        .footer-cta p {
+            font-size: 1.3em;
+            margin-bottom: 30px;
+            opacity: 0.95;
+        }
+        
+        /* Footer */
+        footer {
+            text-align: center;
+            padding: 30px 20px;
+            background-color: #2c3e50;
+            color: #95a5a6;
+            font-size: 0.9em;
+        }
+        footer a {
+            color: var(--color-accent);
+            text-decoration: none;
+        }
+        footer a:hover {
+            text-decoration: underline;
+        }
+        
+        @media (max-width: 768px) {
+            .hero h1 {
+                font-size: 2em;
+            }
+            .hero .subtitle {
+                font-size: 1.1em;
+            }
+            .solution h2, .features h2, .how-it-works h2, .use-cases h2, .faq h2 {
+                font-size: 1.8em;
+            }
+        }
+    </style>
+</head>
+<body>
+
+    <!-- Hero Section -->
+    <div class="hero">
+        <div class="container">
+            <h1>🚢 Shiplog: Git-Native Deployment Journal</h1>
+            <p class="subtitle">
+                Auditable deployment logs that live in your git repo. Cryptographically signed, append-only, and offline-capable.
+            </p>
+            
+            <div class="problem">
+                <p><strong>2:47 AM.</strong> Production is on fire. Your logging vendor is down. Slack history caps at 90 days. CI logs expired last week. You need to know: <em>What deployed? When? Who approved it?</em></p>
+                <p style="margin-top: 15px;"><strong>You're fucked.</strong></p>
+            </div>
+            
+            <div style="margin-top: 40px;">
+                <a href="#installation" class="cta-primary">Get Started</a>
+                <a href="https://github.com/flyingrobots/shiplog" class="cta-secondary" target="_blank">View on GitHub</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- The Solution -->
+    <div class="solution">
+        <div class="container">
+            <h2>Shiplog Prevents This</h2>
+            <p class="tagline">Your deployment history lives in your git repo. Forever. Offline. Cryptographically signed.</p>
+            
+            <div class="code-block">
+<pre><span class="code-prompt">$</span> git shiplog show
+<span class="code-output">┌ SHIPLOG Entry ────────────────────────────────────────────────┐
+│ Deploy: api-service v2.1.4 → prod/us-east-1/prod-a/default   │
+│ Reason: Hotfix for rate limiting bug                         │
+│ Status: SUCCESS (2m34s) @ 2025-09-30T02:38:42Z               │
+│ By: alice@example.com (signed)                               │
+│ Commit: a7f3c2d                                               │
+└───────────────────────────────────────────────────────────────┘</span></pre>
+            </div>
+            
+            <p style="text-align: center; font-size: 1.2em; margin-top: 30px;">
+                <strong>Three seconds.</strong> That's how long it takes to know exactly what happened.
+            </p>
+        </div>
+    </div>
+
+    <!-- Features -->
+    <div class="features">
+        <div class="container">
+            <h2>Why Shiplog?</h2>
+            
+            <div class="feature-grid">
+                <div class="feature-card">
+                    <span class="feature-icon">🪢</span>
+                    <h3>Git-Native</h3>
+                    <p>Your history lives in git refs. No databases, no APIs, no external services. Just <code>git push</code> and <code>git pull</code>. Works offline. Works in 20 years.</p>
+                </div>
+                
+                <div class="feature-card">
+                    <span class="feature-icon">🔏</span>
+                    <h3>Cryptographically Signed</h3>
+                    <p>Every entry is a signed git commit. Tamper-evident. Auditable. Compliance-ready. Uses your existing GPG/SSH keys.</p>
+                </div>
+                
+                <div class="feature-card">
+                    <span class="feature-icon">📊</span>
+                    <h3>Machine Parseable</h3>
+                    <p>Structured JSON trailers. Pipe to <code>jq</code>, feed to compliance tools, or build dashboards. Human-readable AND automation-friendly.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- How It Works -->
+    <div class="how-it-works">
+        <div class="container">
+            <h2>How It Works</h2>
+            <p class="intro">Shiplog wraps your deployment commands and automatically journals their execution. Exit codes, duration, output—everything captured and committed.</p>
+            
+            <div class="demo-section">
+                <h3>1. Wrap Your Deploy Commands</h3>
+                <p>Run any command through Shiplog to automatically capture and journal its execution:</p>
+                <div class="code-block">
+<pre><span class="code-prompt">$</span> git shiplog run \
+    --service api-service \
+    --reason "Rolling out v2.1.4" \
+    --env prod \
+    -- kubectl rollout status deploy/api-service
+
+<span class="code-output">Waiting for deployment "api-service" rollout to finish: 2 of 3 updated replicas...
+deployment "api-service" successfully rolled out
+
+Deploy: api-service v2.1.4 → prod/us-east-1/prod-a/default
+Reason: Rolling out v2.1.4
+Status: SUCCESS (45s) @ 2025-09-30T14:23:17Z</span></pre>
+                </div>
+            </div>
+            
+            <div class="demo-section">
+                <h3>2. Append Custom Metadata</h3>
+                <p>Push structured data from your CI/CD pipeline:</p>
+                <div class="code-block">
+<pre><span class="code-prompt">$</span> echo '{"tests_passed": 847, "coverage": 94.2}' | \
+  git shiplog append \
+    --env prod \
+    --service api-service \
+    --status success \
+    --json -
+
+<span class="code-output">Record: api-service → prod
+Status: SUCCESS @ 2025-09-30T14:25:03Z</span></pre>
+                </div>
+            </div>
+            
+            <div class="demo-section">
+                <h3>3. Audit & Export</h3>
+                <p>Query your deployment history with tools you already know:</p>
+                <div class="code-block">
+<pre><span class="code-prompt">$</span> git log --oneline refs/_shiplog/journal/prod | head -5
+<span class="code-output">a7f3c2d Deploy api-service v2.1.4 → prod (SUCCESS)
+f8e2b1a Deploy web-frontend v1.8.2 → prod (SUCCESS)  
+d4a9c7f Deploy api-service v2.1.3 → prod (FAILURE)
+c3f8e2d Deploy worker-service v3.0.1 → prod (SUCCESS)</span>
+
+<span class="code-prompt">$</span> git shiplog export-json | jq '.[] | select(.status == "FAILURE")'
+<span class="code-output">{
+  "service": "api-service",
+  "version": "v2.1.3",
+  "status": "FAILURE",
+  "timestamp": "2025-09-29T18:42:11Z",
+  "reason": "Database migration timeout"
+}</span></pre>
+                </div>
+            </div>
+            
+            <div class="demo-section">
+                <h3>4. Verify Signatures</h3>
+                <p>Prove who performed each deployment:</p>
+                <div class="code-block">
+<pre><span class="code-prompt">$</span> git log --show-signature refs/_shiplog/journal/prod -1
+<span class="code-output">commit a7f3c2d3f8e2b1a9c7f4d6e8
+gpg: Signature made Mon 30 Sep 2025 02:38:42 PM UTC
+gpg: Good signature from "Alice Engineer &lt;alice@example.com&gt;"
+Deploy api-service v2.1.4 → prod (SUCCESS)</span></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Installation -->
+    <div class="installation" id="installation">
+        <div class="container">
+            <h2>Installation</h2>
+            <p class="intro">Get started in under 60 seconds. No package managers, no dependencies beyond bash and git.</p>
+            
+            <div class="install-steps">
+                <div class="install-step">
+                    <h4>1. Clone the repo</h4>
+                    <div class="code-block">
+<pre><span class="code-prompt">$</span> git clone https://github.com/flyingrobots/shiplog.git ~/.shiplog</pre>
+                    </div>
+                </div>
+                
+                <div class="install-step">
+                    <h4>2. Add to your PATH</h4>
+                    <div class="code-block">
+<pre><span class="code-prompt">$</span> export PATH="$HOME/.shiplog/bin:$PATH"
+<span class="code-comment"># Add to ~/.bashrc or ~/.zshrc to make permanent</span></pre>
+                    </div>
+                </div>
+                
+                <div class="install-step">
+                    <h4>3. Initialize in your repo</h4>
+                    <div class="code-block">
+<pre><span class="code-prompt">$</span> cd your-project
+<span class="code-prompt">$</span> git shiplog init --env prod
+<span class="code-output">Initialized Shiplog journal: refs/_shiplog/journal/prod</span></pre>
+                    </div>
+                </div>
+                
+                <div class="install-step">
+                    <h4>4. Start logging</h4>
+                    <div class="code-block">
+<pre><span class="code-prompt">$</span> git shiplog run --service myapp --reason "First deploy" -- echo "Hello Shiplog"
+<span class="code-output">Hello Shiplog
+Deploy: myapp → prod
+Status: SUCCESS (0s) @ 2025-09-30T14:30:00Z</span></pre>
+                    </div>
+                </div>
+            </div>
+            
+            <div style="text-align: center; margin-top: 40px;">
+                <a href="https://github.com/flyingrobots/shiplog#installation" class="cta-primary">Full Installation Guide</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Use Cases -->
+    <div class="use-cases">
+        <div class="container">
+            <h2>Who Uses Shiplog?</h2>
+            
+            <div class="use-case-grid">
+                <div class="use-case">
+                    <h4>🏢 Compliance Teams</h4>
+                    <ul>
+                        <li>Immutable audit trail</li>
+                        <li>Cryptographic signatures</li>
+                        <li>SOC2/HIPAA-ready</li>
+                        <li>Export to compliance tools</li>
+                    </ul>
+                </div>
+                
+                <div class="use-case">
+                    <h4>🔧 DevOps Engineers</h4>
+                    <ul>
+                        <li>Incident forensics</li>
+                        <li>Deployment tracking</li>
+                        <li>No vendor lock-in</li>
+                        <li>Works offline</li>
+                    </ul>
+                </div>
+                
+                <div class="use-case">
+                    <h4>🤖 CI/CD Pipelines</h4>
+                    <ul>
+                        <li>Automation-friendly API</li>
+                        <li>Structured JSON output</li>
+                        <li>Zero external services</li>
+                        <li>No API rate limits</li>
+                    </ul>
+                </div>
+                
+                <div class="use-case">
+                    <h4>🔐 Security Teams</h4>
+                    <ul>
+                        <li>Tamper-evident logs</li>
+                        <li>Trust roster management</li>
+                        <li>Multi-signature support</li>
+                        <li>Policy as code</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- FAQ -->
+    <div class="faq">
+        <div class="container">
+            <h2>Frequently Asked Questions</h2>
+            
+            <div class="faq-item">
+                <h4>Why not just use CloudWatch/Datadog/Splunk?</h4>
+                <p>Those are excellent for log aggregation and real-time monitoring. Shiplog solves a different problem: <strong>immutable audit trail that can't be deleted by an outage or a billing lapse.</strong> It's complementary, not competitive. Plus, it's free and works offline.</p>
+            </div>
+            
+            <div class="faq-item">
+                <h4>Is bash really the right choice for production tooling?</h4>
+                <p>Yes. Bash keeps dependencies at zero, runs everywhere git runs, and makes the code auditable in 5 minutes. You're journaling deployments, not parsing petabytes of logs. The bottleneck is git, not bash. If that changes, we'll port the hot paths. But it won't.</p>
+            </div>
+            
+            <div class="faq-item">
+                <h4>What about scale? Can it handle 1000s of deployments?</h4>
+                <p>Even aggressive teams deploy ~100 times per day. Git handles that trivially. We've tested with 10,000+ entries—works fine. Remember: this is append-only history, not real-time log streaming.</p>
+            </div>
+            
+            <div class="faq-item">
+                <h4>How do I share deployment history across my team?</h4>
+                <p>It's just git. <code>git push origin refs/_shiplog/journal/*</code> and your team can <code>git fetch</code>. No special infrastructure needed. Works with any git hosting (GitHub, GitLab, Bitbucket, self-hosted).</p>
+            </div>
+            
+            <div class="faq-item">
+                <h4>What if someone force-pushes and rewrites history?</h4>
+                <p>Git's signature verification catches that. Every entry is signed, and tampering breaks the signature chain. Plus, you can enforce branch protection rules on your journal refs just like you do for main.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer CTA -->
+    <div class="footer-cta">
+        <div class="container">
+            <h2>Ready to Ship?</h2>
+            <p>Stop losing deployment history to vendor outages and expired logs.</p>
+            <a href="#installation" class="cta-primary" style="background-color: white; color: var(--color-secondary);">Install Shiplog Now</a>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer>
+        <p>MIT License © 2025 • Built by <a href="https://github.com/flyingrobots" target="_blank">J. Kirby Ross</a></p>
+        <p>Shiplog is a primitive, not a platform. <a href="https://github.com/flyingrobots/shiplog" target="_blank">Fork it</a> • <a href="https://github.com/flyingrobots/shiplog/issues" target="_blank">Issues</a> • <a href="https://github.com/flyingrobots/shiplog/blob/main/docs/README.md" target="_blank">Docs</a></p>
+    </footer>
+
+</body>
+</html>

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -30,6 +30,12 @@ This is a compact reference for key `SHIPLOG_*` environment variables. Most can 
 - `SHIPLOG_ASSUME_YES` — Auto-confirm prompts (same as `--yes`)
   - Values: `1` or `0` (default)
 
+## UX
+
+- `SHIPLOG_CONFIRM_TEXT` — Override the confirmation line printed by `git shiplog run` after a successful write.
+  - Default: the log emoji `🪵`
+  - Example: `export SHIPLOG_CONFIRM_TEXT="> Shiplogged"`
+
 ## Policy & Signing
 
 - `SHIPLOG_AUTHORS` — Space-separated allowlist of authors (emails). Overrides policy.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -48,10 +48,15 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
 
 **Currently Active:** Alpha
 
+### HOTFIX (unscored)
+
+- Backlog:
+  - [SLT.HOTFIX.001 — Enforce trust threshold in pre-receive hook](docs/tasks/backlog/SLT.HOTFIX.001_enforce_trust_threshold_in_pre_receive.md)
+
 <!-- progress bar: Overall -->
 #### Overall
 ```text
-███████████████████████████████░░░░░░░░░░░░░░░░░░░ 63% (weighted)
+███████████████████████████████░░░░░░░░░░░░░░░░░░░ 62% (weighted)
 |••••|••••|••••|••••|••••|••••|••••|••••|••••|••••|
 0   10   20   30   40   50   60   70   80   90  100%
 ```
@@ -75,7 +80,7 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
 <!-- progress bar: Alpha -->
 #### Alpha
 ```text
-████████████████████████████████████░░░░░░░░░░░░░░ 72% (48/63)
+██████████████████████████████████░░░░░░░░░░░░░░░░ 68% (48/67)
 |••••|••••|••••|••••|••••|••••|••••|••••|••••|••••|
 0   10   20   30   40   50   60   70   80   90  100%
 ```
@@ -151,7 +156,7 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
 <!-- progress bar: Beta -->
 #### Beta
 ```text
-█████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 11% (2/16)
+████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 9% (2/18)
 |••••|••••|••••|••••|••••|••••|••••|••••|••••|••••|
 0   10   20   30   40   50   60   70   80   90  100%
 ```
@@ -171,6 +176,8 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
   - [SLT.BETA.011 — Optimize Bosun table parsing](docs/tasks/backlog/SLT.BETA.011_optimize_bosun_table_parsing.md)
   - [SLT.BETA.012 — Require perl for ANSI stripping](docs/tasks/backlog/SLT.BETA.012_require_perl_for_ansi_stripping.md)
   - [SLT.BETA.013 — Improve split helper implementation](docs/tasks/backlog/SLT.BETA.013_improve_bosun_split_helper.md)
+  - [SLT.BETA.017 — Enforce policy fields: require_ticket/require_where/ff_only](docs/tasks/backlog/SLT.BETA.017_enforce_policy_fields_require_ticket_where_ff_only.md)
+  - [SLT.BETA.018 — Anchors lifecycle: commands and flow](docs/tasks/backlog/SLT.BETA.018_anchor_commands_and_flow.md)
 
 <!-- progress bar: v1.0.0 -->
 #### v1.0.0
@@ -184,5 +191,13 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
 - Backlog:
   - [SLT.V1.001 — Design extension/plugin system](docs/tasks/backlog/SLT.V1.001_plugin_system.md)
   - [SLT.V1.002 — Integrate secrets scrubber](docs/tasks/backlog/SLT.V1.002_secrets_scrubber.md)
+
+### Alpha (additional backlog)
+
+- Backlog (new):
+  - [SLT.ALPHA.019 — Align unsigned mode with trust requirement](docs/tasks/backlog/SLT.ALPHA.019_unsigned_mode_trust_requirement_alignment.md)
+  - [SLT.ALPHA.020 — Align policy schema, writers, and CI validation](docs/tasks/backlog/SLT.ALPHA.020_policy_schema_alignment_and_validation.md)
+  - [SLT.ALPHA.021 — Fix docs test reference and ls status semantics](docs/tasks/backlog/SLT.ALPHA.021_docs_fix_test_ref_and_ls_status.md)
+  - [SLT.ALPHA.022 — Add CONTRIBUTING, Code of Conduct, and Security docs](docs/tasks/backlog/SLT.ALPHA.022_repo_hygiene_policies.md)
 
 <!-- tasks-moc:end -->

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -156,7 +156,7 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
 <!-- progress bar: Beta -->
 #### Beta
 ```text
-████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 9% (2/18)
+████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 8% (2/20)
 |••••|••••|••••|••••|••••|••••|••••|••••|••••|••••|
 0   10   20   30   40   50   60   70   80   90  100%
 ```
@@ -178,6 +178,8 @@ The following is the canonical progress bar. *Note that it is 50 characters wide
   - [SLT.BETA.013 — Improve split helper implementation](docs/tasks/backlog/SLT.BETA.013_improve_bosun_split_helper.md)
   - [SLT.BETA.017 — Enforce policy fields: require_ticket/require_where/ff_only](docs/tasks/backlog/SLT.BETA.017_enforce_policy_fields_require_ticket_where_ff_only.md)
   - [SLT.BETA.018 — Anchors lifecycle: commands and flow](docs/tasks/backlog/SLT.BETA.018_anchor_commands_and_flow.md)
+  - [SLT.BETA.019 — Git hosting enforcement matrix and guidance](docs/tasks/backlog/SLT.BETA.019_git_hosting_enforcement_matrix.md)
+  - [SLT.BETA.020 — Setup Questionnaire (guided configuration)](docs/tasks/backlog/SLT.BETA.020_setup_questionnaire.md)
 
 <!-- progress bar: v1.0.0 -->
 #### v1.0.0

--- a/docs/tasks/backlog/SLT.ALPHA.019_unsigned_mode_trust_requirement_alignment.md
+++ b/docs/tasks/backlog/SLT.ALPHA.019_unsigned_mode_trust_requirement_alignment.md
@@ -1,0 +1,23 @@
+{
+  "id": "SLT.ALPHA.019",
+  "labels": ["cli", "trust", "docs", "policy"],
+  "milestone": "Alpha",
+  "name": "Align unsigned mode with trust requirement",
+  "description": "Decide and implement consistent behavior for unsigned mode: either allow missing trust when require_signed=false (and embed trust_oid=null), or explicitly document that trust is always required. Update CLI (cmd_write) and docs to match, and add tests.",
+  "priority": "P1",
+  "impact": "Removes onboarding friction and resolves doc/code mismatch for open/balanced mode.",
+  "steps": [
+    "Choose policy: allow-missing-trust when unsigned vs trust-always-required",
+    "Implement cmd_write behavior (gate trust lookup on effective signing)",
+    "Adjust trailer composer to handle trust_oid=null",
+    "Update docs/features/modes.md and setup docs accordingly",
+    "Add Bats tests for unsigned write with/without trust"
+  ],
+  "blocked_by": [],
+  "notes": ["If keeping 'trust always required', simplify docs to state that explicitly"],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "med",
+  "expected_complexity": "medium"
+}
+

--- a/docs/tasks/backlog/SLT.ALPHA.020_policy_schema_alignment_and_validation.md
+++ b/docs/tasks/backlog/SLT.ALPHA.020_policy_schema_alignment_and_validation.md
@@ -1,0 +1,23 @@
+{
+  "id": "SLT.ALPHA.020",
+  "labels": ["policy", "schema", "ci", "docs"],
+  "milestone": "Alpha",
+  "name": "Align policy schema, writers, and CI validation",
+  "description": "Make the policy schema authoritative or trim it to the enforced subset. Update writers (setup, policy require-signed) to emit the chosen shape, adopt AJV validation in CI, and make jq-based validation optional only inside containers.",
+  "priority": "P2",
+  "impact": "Eliminates confusion and failures from schema/doc drift; ensures policies are validated consistently.",
+  "steps": [
+    "Decide schema direction: full semver/object vs minimal numeric version",
+    "Update examples/policy.schema.json and docs/policy.md to match",
+    "Update CLI writers to emit compliant JSON",
+    "Add CI job using ajv-cli to validate .shiplog/policy.json",
+    "Make scripts/shiplog-sync-policy.sh surface validation errors clearly"
+  ],
+  "blocked_by": [],
+  "notes": ["Prefer ajv in CI; keep jq --schema only when available in containers"],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "med",
+  "expected_complexity": "medium"
+}
+

--- a/docs/tasks/backlog/SLT.ALPHA.021_docs_fix_test_ref_and_ls_status.md
+++ b/docs/tasks/backlog/SLT.ALPHA.021_docs_fix_test_ref_and_ls_status.md
@@ -1,0 +1,20 @@
+{
+  "id": "SLT.ALPHA.021",
+  "labels": ["docs"],
+  "milestone": "Alpha",
+  "name": "Fix docs test reference and ls status semantics",
+  "description": "Correct docs/features/write.md to reference test/10_run_command.bats and document that ls shows the human Status line (not just the bare status enum).",
+  "priority": "P3",
+  "impact": "Removes minor confusion in docs; improves accuracy.",
+  "steps": [
+    "Update docs/features/write.md test reference",
+    "Clarify ls status column description in docs/features/ls.md or command reference"
+  ],
+  "blocked_by": [],
+  "notes": [],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "small",
+  "expected_complexity": "low"
+}
+

--- a/docs/tasks/backlog/SLT.ALPHA.022_repo_hygiene_policies.md
+++ b/docs/tasks/backlog/SLT.ALPHA.022_repo_hygiene_policies.md
@@ -1,0 +1,22 @@
+{
+  "id": "SLT.ALPHA.022",
+  "labels": ["docs", "github"],
+  "milestone": "Alpha",
+  "name": "Add CONTRIBUTING, Code of Conduct, and Security docs",
+  "description": "Add CONTRIBUTING.md (including lint/test guidance), CODE_OF_CONDUCT.md, and SECURITY.md (vuln disclosure). Link from README and repository community health files.",
+  "priority": "P2",
+  "impact": "Improves public repo readiness and contributor experience.",
+  "steps": [
+    "Draft CONTRIBUTING.md with test/lint instructions and Dockerized tests",
+    "Add CODE_OF_CONDUCT.md (Contributor Covenant)",
+    "Add SECURITY.md with reporting instructions",
+    "Link from README and .github/ settings where appropriate"
+  ],
+  "blocked_by": [],
+  "notes": [],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "small",
+  "expected_complexity": "low"
+}
+

--- a/docs/tasks/backlog/SLT.BETA.017_enforce_policy_fields_require_ticket_where_ff_only.md
+++ b/docs/tasks/backlog/SLT.BETA.017_enforce_policy_fields_require_ticket_where_ff_only.md
@@ -1,0 +1,22 @@
+{
+  "id": "SLT.BETA.017",
+  "labels": ["policy", "hooks", "cli"],
+  "milestone": "Beta",
+  "name": "Enforce policy fields: require_ticket/require_where/ff_only",
+  "description": "Implement enforcement of documented policy fields. Validate required ticket/service/where fields in CLI (write) and server hook, and honor ff_only at policy level (complementing current per-ref FF checks).",
+  "priority": "P2",
+  "impact": "Brings real enforcement in line with policy documentation; increases operational safety.",
+  "steps": [
+    "CLI: validate required fields before composing commit",
+    "Hook: enforce required fields by parsing trailer JSON",
+    "Hook: enforce ff_only via policy switch (keep current FF checks as baseline)",
+    "Docs: examples and guidance"
+  ],
+  "blocked_by": ["SLT.ALPHA.020"],
+  "notes": [],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "med",
+  "expected_complexity": "medium"
+}
+

--- a/docs/tasks/backlog/SLT.BETA.018_anchor_commands_and_flow.md
+++ b/docs/tasks/backlog/SLT.BETA.018_anchor_commands_and_flow.md
@@ -1,0 +1,22 @@
+{
+  "id": "SLT.BETA.018",
+  "labels": ["anchors", "cli", "hooks"],
+  "milestone": "Beta",
+  "name": "Anchors lifecycle: commands and flow",
+  "description": "Design and implement anchor operations for refs/_shiplog/anchors/<env>. Provide a command to create/move an anchor, update trailer semantics, and (optionally) enforce linearity between anchors.",
+  "priority": "P3",
+  "impact": "Enables useful \"since last anchor\" reporting and navigation across long journals.",
+  "steps": [
+    "Define anchor semantics and UX",
+    "Implement git shiplog anchor [create|move|show]",
+    "Wire anchors into write/run flows as appropriate",
+    "Add docs and examples"
+  ],
+  "blocked_by": [],
+  "notes": ["Keep anchor operations fast-forward only"],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "med",
+  "expected_complexity": "medium"
+}
+

--- a/docs/tasks/backlog/SLT.BETA.020_setup_questionnaire.md
+++ b/docs/tasks/backlog/SLT.BETA.020_setup_questionnaire.md
@@ -1,0 +1,27 @@
+{
+  "id": "SLT.BETA.020",
+  "labels": ["cli", "setup", "ux", "docs"],
+  "milestone": "Beta",
+  "name": "Setup Questionnaire (guided configuration)",
+  "description": "Add an interactive setup questionnaire that asks targeted questions (hosting, enforcement, PR workflow, threshold, key types, deployment cadence) and produces a tailored Shiplog configuration: signing mode (chain/attestation), threshold, trust bootstrap choices, ref namespace (custom vs branch), auto-push policy, and CI/Ruleset recommendations. Provide a non-interactive mode that accepts pre-answered choices.",
+  "priority": "P1",
+  "impact": "Reduces onboarding friction; yields sane, host-aware defaults and fewer misconfigurations.",
+  "steps": [
+    "Design question set and mapping to outputs (sig_mode, threshold, ref root, autoPush, workflows)",
+    "Implement CLI: git shiplog setup --questionnaire (TTY UI via Bosun + plain fallback)",
+    "Emit: .shiplog/policy.json, trust bootstrap flags, suggested CI workflow and ruleset snippets",
+    "Add non-interactive mode: accept answers via JSON/flags and print a plan",
+    "Docs: how it works + examples; link from README and TRUST docs",
+    "Tests: Dockerized bats covering key decision branches"
+  ],
+  "blocked_by": ["SLT.BETA.019"],
+  "notes": [
+    "Answers include: host (GitHub.com/GitLab/Gitea/self-hosted), PR style (squash vs multi-commit), enforcement preference, threshold typical, key types, deploy cadence, pushing during deploys",
+    "Outputs include: sig_mode, recommended required checks, ruleset/protection guidance, auto-push default, publish advice"
+  ],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "big",
+  "expected_complexity": "high"
+}
+

--- a/docs/tasks/backlog/SLT.HOTFIX.001_enforce_trust_threshold_in_pre_receive.md
+++ b/docs/tasks/backlog/SLT.HOTFIX.001_enforce_trust_threshold_in_pre_receive.md
@@ -1,0 +1,27 @@
+{
+  "id": "SLT.HOTFIX.001",
+  "labels": ["hooks", "trust", "security"],
+  "milestone": "HOTFIX",
+  "name": "Enforce trust threshold in pre-receive hook",
+  "description": "Update contrib/hooks/pre-receive.shiplog to verify that updates to refs/_shiplog/trust/root are co-signed by at least the configured threshold of maintainers in trust.json. Reject pushes that do not meet the N-of-M requirement.",
+  "priority": "P0",
+  "impact": "Prevents unauthorized or under-signed trust changes; closes a critical integrity gap for production deployments.",
+  "steps": [
+    "Parse trust.json (threshold, maintainers) from new trust tip",
+    "Collect valid signatures on the new trust commit (SSH or OpenPGP)",
+    "Map signatures to maintainer principals/keys; count distinct maintainers",
+    "Reject if count < threshold; include friendly error with details",
+    "Add Dockerized Bats tests for passing/failing updates",
+    "Document behavior in docs/TRUST.md and contrib/README.md"
+  ],
+  "blocked_by": [],
+  "notes": [
+    "For SSH signatures, use GIT_SSH_ALLOWED_SIGNERS with the allowed_signers blob to validate each signature",
+    "For PGP, verify via git verify-commit and parse signers; prefer SSH in CI"
+  ],
+  "created": "2025-10-03",
+  "updated": "2025-10-03",
+  "estimate": "med",
+  "expected_complexity": "high"
+}
+

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -1339,6 +1339,10 @@ cmd_setup() {
         shift; [ -n "${1:-}" ] || die "shiplog: --trust-maintainer requires a value"; trust_args+=("--trust-maintainer" "$1"); shift ;;
       --trust-maintainer=*)
         trust_args+=("--trust-maintainer=${1#*=}"); shift ;;
+      --trust-sig-mode)
+        shift; [ -n "${1:-}" ] || die "shiplog: --trust-sig-mode requires a value"; trust_args+=("--trust-sig-mode" "$1"); shift ;;
+      --trust-sig-mode=*)
+        trust_args+=("--trust-sig-mode=${1#*=}"); shift ;;
       --trust-message)
         shift; [ -n "${1:-}" ] || die "shiplog: --trust-message requires a value"; trust_args+=("--trust-message" "$1"); shift ;;
       --trust-message=*)

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -754,9 +754,9 @@ cmd_run() {
     tip=$(git rev-parse --short "$(ref_journal "$env")" 2>/dev/null || echo "")
     local msg
     if [ -n "$tip" ]; then
-      msg="Recorded to Shiplog [$tip]"
+      msg="Stowed away [$tip]"
     else
-      msg="Recorded to Shiplog"
+      msg="Stowed away"
     fi
     if shiplog_can_use_bosun; then
       local bosun

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -753,11 +753,10 @@ cmd_run() {
     local tip
     tip=$(git rev-parse --short "$(ref_journal "$env")" 2>/dev/null || echo "")
     local msg
-    if [ -n "$tip" ]; then
-      msg="Stowed away [$tip]"
-    else
-      msg="Stowed away"
-    fi
+    # Minimal confirmation; customizable via SHIPLOG_CONFIRM_TEXT (default: log emoji)
+    local confirm_text
+    confirm_text="${SHIPLOG_CONFIRM_TEXT:-🪵}"
+    msg="$confirm_text"
     if shiplog_can_use_bosun; then
       local bosun
       bosun=$(shiplog_bosun_bin)

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -762,7 +762,7 @@ cmd_run() {
       bosun=$(shiplog_bosun_bin)
       "$bosun" style --title "Shiplog" -- "$msg"
     else
-      printf '✅ %s\n' "$msg"
+      printf '%s\n' "$msg"
     fi
   else
     printf '❌ shiplog: failed to record run entry; log preserved at %s\n' "$log_path" >&2

--- a/scripts/shiplog-verify-trust.sh
+++ b/scripts/shiplog-verify-trust.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shiplog-verify-trust.sh — verify a trust update for threshold and mode
+# Usage:
+#   shiplog-verify-trust.sh --old <old_oid|0> --new <new_oid> [--ref <ref>]
+#
+# Behavior v0 (initial):
+#   - Always require the new trust commit to be signature-verified.
+#   - If threshold == 1: accept after signature verification.
+#   - If threshold > 1 and sig_mode == chain: ensure the update range contains
+#     commits all sharing the same tree, each signature verifies, and at least
+#     <threshold> distinct maintainer emails appear as authors.
+#   - If threshold > 1 and sig_mode == attestation: ensure at least <threshold>
+#     files exist under .shiplog/trust_sigs/ (minimal check). If ssh-keygen is
+#     available and allowed_signers is present, attempt to verify each signature
+#     over the canonical payload; otherwise emit a warning and reject unless
+#     SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED=1.
+
+err() { echo "❌ shiplog: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || err "missing dependency: $1"; }
+
+OLD=""; NEW=""; REF="refs/_shiplog/trust/root"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --old) shift; OLD="${1:-}" ;;
+    --new) shift; NEW="${1:-}" ;;
+    --ref) shift; REF="${1:-}" ;;
+    *) err "unknown arg: $1" ;;
+  esac
+  shift || true
+done
+
+[ -n "$NEW" ] || err "--new is required"
+[ -n "$OLD" ] || OLD="0000000000000000000000000000000000000000"
+
+JQ_BIN="${SHIPLOG_JQ_BIN:-jq}"
+need git; need "$JQ_BIN"
+
+load_blob() { git show "$1:$2" 2>/dev/null || true; }
+
+TRUST_JSON=$(load_blob "$NEW" "trust.json")
+[ -n "$TRUST_JSON" ] || err "trust.json missing in $REF@${NEW}"
+
+threshold=$(printf '%s' "$TRUST_JSON" | "$JQ_BIN" -r '.threshold // 1')
+sig_mode=$(printf '%s' "$TRUST_JSON" | "$JQ_BIN" -r '.sig_mode // "chain"')
+[ -n "$sig_mode" ] || sig_mode="chain"
+
+signers_blob=$(load_blob "$NEW" "allowed_signers")
+SIGNERS_FILE=""
+if [ -n "$signers_blob" ]; then
+  SIGNERS_FILE=$(mktemp)
+  printf '%s' "$signers_blob" > "$SIGNERS_FILE"
+  chmod 600 "$SIGNERS_FILE"
+fi
+
+verify_commit_sig() {
+  local c="$1"
+  if [ -n "$SIGNERS_FILE" ]; then
+    GIT_SSH_ALLOWED_SIGNERS="$SIGNERS_FILE" git verify-commit "$c" >/dev/null 2>&1 || return 1
+  else
+    git verify-commit "$c" >/dev/null 2>&1 || return 1
+  fi
+}
+
+# 1) Always require the new trust commit to be signature-verified.
+verify_commit_sig "$NEW" || err "trust commit $NEW failed signature verification"
+
+# 2) Threshold==1 is satisfied now.
+if [ "$threshold" = "1" ] || [ "$threshold" = "1.0" ]; then
+  exit 0
+fi
+
+if ! printf '%s' "$threshold" | grep -Eq '^[1-9][0-9]*$'; then
+  err "invalid threshold: $threshold"
+fi
+
+trust_tree_oid() {
+  git show -s --format='%T' "$1"
+}
+
+if [ "$sig_mode" = "chain" ]; then
+  # Range is either NEW if OLD is zero, or NEW ^OLD
+  if [ "$OLD" = "0000000000000000000000000000000000000000" ]; then
+    err "threshold>1 requires multiple co-signed commits in chain mode"
+  fi
+  local tree expected
+  expected=$(trust_tree_oid "$NEW")
+  count=0
+  authors_seen=""
+  while read -r c; do
+    [ -n "$c" ] || continue
+    verify_commit_sig "$c" || err "co-sign commit $c failed signature verification"
+    tree=$(trust_tree_oid "$c")
+    [ "$tree" = "$expected" ] || err "co-sign commit $c does not match trust tree"
+    ae=$(git show -s --format='%ae' "$c")
+    case " $authors_seen " in *" $ae "*) : ;; *) authors_seen="$authors_seen $ae"; count=$((count+1));; esac
+  done < <(git rev-list --ancestry-path "$OLD..$NEW")
+  if [ "$count" -lt "$threshold" ]; then
+    err "co-sign chain has $count maintainer commits; threshold is $threshold"
+  fi
+  exit 0
+fi
+
+if [ "$sig_mode" = "attestation" ]; then
+  # Minimal: require at least <threshold> files under .shiplog/trust_sigs/
+  mapfile -t sigs < <(git ls-tree -r --name-only "$NEW" | awk '/^\.shiplog\/trust_sigs\//{print}')
+  nsigs=${#sigs[@]}
+  if [ "$nsigs" -lt "$threshold" ] && [ "${SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED:-0}" != "1" ]; then
+    err "found $nsigs attestation files; threshold is $threshold"
+  fi
+  # TODO: Verify each signature over canonical payload when ssh-keygen is present.
+  exit 0
+fi
+
+err "unknown sig_mode: $sig_mode"
+


### PR DESCRIPTION
Summary
- Adds the first cut of trust verification and mode selection:
  - trust.json: new "sig_mode": "chain" | "attestation".
  - scripts/shiplog-verify-trust.sh: shared verifier for hooks and CI.
  - contrib/hooks/pre-receive.shiplog: calls shared verifier when present; strict fallback requires a valid signature and blocks threshold>1 unless an explicit env escape hatch is set.
- SaaS-friendly enforcement:
  - docs/examples/github/workflow-shiplog-trust-verify.yml: Required Status Check workflow for _shiplog/**.
- UX polish:
  - git shiplog run: streams command output and prints a minimal confirmation (default “🪵”); override via SHIPLOG_CONFIRM_TEXT.
  - Human header hides missing location parts (no “?/?”); ls reads JSON where possible and uses “-” for missing values.
- Push behavior and new publish command:
  - write/run now respect repo config: git config shiplog.autoPush {true|false}, with CLI flags still taking precedence.
  - New: git shiplog publish [--env ENV] [--no-notes] [--policy] [--trust] [--all] to push journals/notes (and optionally policy/trust) at the end of a deploy.

Changes (files)
- contrib/hooks/pre-receive.shiplog: trust verification call + strict fallback.
- scripts/shiplog-verify-trust.sh: shared verifier (chain checks fully implemented; attestation presence checks for now).
- scripts/shiplog-bootstrap-trust.sh: --trust-sig-mode and “sig_mode” written to trust.json; prompt added in interactive mode.
- lib/git.sh: compact location header; ls reads JSON and hides missing values.
- lib/commands.sh:
  - run: minimal confirmation (emoji by default; SHIPLOG_CONFIRM_TEXT override).
  - new cmd_publish; auto-push respects repo config shiplog.autoPush.
- bin/git-shiplog: track whether --push/--no-push was passed so flags override config.
- Docs:
  - RELEASE_NOTES.md (upgrade guide and SaaS/self-hosted steps).
  - docs/TRUST.md (sig_mode, enforcement).
  - docs/features/{run,write,ls,command-reference}.md (new behavior).
  - docs/reference/env.md (SHIPLOG_CONFIRM_TEXT).
  - docs/examples/github/workflow-shiplog-trust-verify.yml (Required Check template).

Backwards compatibility
- If trust.json lacks "sig_mode", defaults to chain; threshold==1 keeps working.
- Journal format unchanged; existing entries remain valid.
- Auto-push default unaffected unless a repo sets git config shiplog.autoPush=false (flags still override).

Operational notes
- Self-hosted: install updated pre-receive hook and include scripts/shiplog-verify-trust.sh alongside the repo; remove SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED when ready.
- SaaS: move Shiplog refs to branch namespace (_shiplog/**), protect them, and add the trust-verify workflow as a Required Status Check.

Testing guidance
- Local smoke:
  - threshold=1: write/run succeeds; trust commit signature verification passes.
  - chain mode (threshold>1): create co-sign chain over identical tree; verifier accepts with ≥ threshold distinct author emails.
  - attestation mode: presence check passes with ≥ threshold .sig files (strict SSH verification to follow in next PR).
- CI: add the included workflow and mark it required for pushes/PRs to _shiplog/**.

Follow-ups (tracked)
- Strict SSH attestation verification and signer helper.
- Hosting matrix doc (GitHub/GitLab/Bitbucket/Gitea).
- Setup Questionnaire (guided configuration).

Screenshots/snippets
- Run confirmation (default): 🪵
- Publish at end of deploy:
  - git config shiplog.autoPush false
  - git shiplog run …    # records locally
  - git shiplog publish  # push journals/notes
