### PR TITLE
polish: stabilize publish test; blocking linters with path filters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,27 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      shell: ${{ steps.filter.outputs.shell }}
+      markdown: ${{ steps.filter.outputs.markdown }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shell:
+              - 'bin/git-shiplog'
+              - 'contrib/hooks/**'
+              - '**/*.sh'
+            markdown:
+              - '**/*.md'
   shellcheck:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Install shellcheck
@@ -22,13 +41,15 @@ jobs:
           echo "ShellCheck version:" && shellcheck --version
           SH_FILES=$(git ls-files | grep -E '(^bin/git-shiplog$|^contrib/hooks/[^/]+$|\.sh$)' || true)
           if [ -n "$SH_FILES" ]; then
-            shellcheck -e SC2034 -S style -s bash $SH_FILES || true
+            shellcheck -e SC2034 -S style -s bash $SH_FILES
           else
             echo "No shell files found"
           fi
 
   markdownlint:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.markdown == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -39,7 +60,7 @@ jobs:
         run: npm install -g markdownlint-cli2
       - name: Run markdownlint-cli2
         run: |
-          markdownlint-cli2 || true
+          markdownlint-cli2
 
   yamllint:
     runs-on: ubuntu-latest
@@ -69,7 +90,7 @@ jobs:
           node-version: '20'
       - name: Install ajv-cli
         run: npm install -g ajv-cli
-      - name: Validate policy files against schema
+      - name: Validate policy files against schema (non-blocking for now)
         run: |
           set -euo pipefail
           echo "Validating policy files with ajv"

--- a/test/19_publish_and_autopush_precedence.bats
+++ b/test/19_publish_and_autopush_precedence.bats
@@ -5,8 +5,7 @@ load helpers/common
 setup() {
   shiplog_standard_setup
   git shiplog init >/dev/null
-  git config user.name "Shiplog Test"
-  git config user.email "shiplog-publish@example.com"
+  # Use default test identity from helpers (allowed by policy)
 }
 
 teardown() {
@@ -14,7 +13,6 @@ teardown() {
 }
 
 @test "publish pushes journal regardless of auto-push settings" {
-  skip "publish precedence test flaky in CI; will re-enable after push harness is stabilized"
   # Set env to auto-push, git config to 0, and pass --push to publish
   export SHIPLOG_AUTO_PUSH=0
   git config shiplog.autoPush false
@@ -36,4 +34,8 @@ teardown() {
   # Publish should push even if auto-push settings are disabled (explicit action)
   run git shiplog publish --env staging
   [ "$status" -eq 0 ]
+  # Verify the remote journal ref exists
+  run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"refs/_shiplog/journal/staging"* ]]
 }


### PR DESCRIPTION
- Unskip + stabilize publish precedence test (verifies remote ref; uses default allowed identity).\n- Make shellcheck and markdownlint blocking again; only run when relevant files change via dorny/paths-filter.\n- Keep policy schema check non-blocking for now.\n\nTests: Dockerized suite is green (62/62).