### PR TITLE
Align policy schema, writers, docs, and CI (Alpha 020)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -165,9 +165,26 @@ $files"
           node-version: '20'
       - name: Install ajv-cli
         run: npm install -g ajv-cli
-      - name: Validate policy files against schema (non-blocking for now)
+      - name: Detect policy/schema changes (PRs)
+        if: github.event_name == 'pull_request'
+        id: changed-policy
+        uses: tj-actions/changed-files@v45
+        with:
+          separator: "\n"
+          files: |
+            examples/policy.schema.json
+            .shiplog/policy.json
+            docs/features/policy.md
+            docs/**/*.policy.json
+      - name: Validate policy files against schema
         run: |
           set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ steps.changed-policy.outputs.any_changed }}" != "true" ]; then
+              echo "No policy/schema changes; skipping AJV."
+              exit 0
+            fi
+          fi
           echo "Validating policy files with ajv"
           shopt -s globstar nullglob
           files=( .shiplog/policy.json docs/**/*.policy.json examples/**/*.policy.json )
@@ -175,4 +192,4 @@ $files"
             echo "No policy files found; skipping."
             exit 0
           fi
-          ajv validate --spec=draft2020 -s examples/policy.schema.json -d "${files[@]}" || true
+          ajv validate --spec=draft2020 -s examples/policy.schema.json -d "${files[@]}"

--- a/docs/features/policy.md
+++ b/docs/features/policy.md
@@ -41,6 +41,20 @@ Run `git shiplog policy --boring` for plain-text output or `--json` to integrate
 
 ## Policy File Examples
 
+Required fields:
+- `version` (semver string, e.g., "1.0.0").
+- `authors.default_allowlist` (one or more allowed author emails).
+
+Optional (recommended as you harden policy):
+- `require_signed` (boolean, top-level) — default behavior when not set per-env.
+- `deployment_requirements` (object) — per-environment knobs. Each env may specify:
+  - `require_signed` (boolean)
+  - `require_ticket` (boolean)
+  - `require_service` (boolean)
+  - `require_where` (array: region, cluster, namespace, service, environment)
+- `ff_only` (boolean) — complement fast‑forward protections for Shiplog refs.
+- `notes_ref`, `journals_ref_prefix`, `anchors_ref_prefix` — customize ref layout.
+
 ### Minimal policy.json
 ```json
 {
@@ -85,7 +99,7 @@ Run `git shiplog policy --boring` for plain-text output or `--json` to integrate
 }
 ```
 
-The JSON Schema that validates these files lives at `examples/policy.schema.json`.
+The JSON Schema that validates these files lives at `examples/policy.schema.json`. Both minimal and fuller forms above validate.
 
 ### Validating policies
 ```bash

--- a/examples/policy.schema.json
+++ b/examples/policy.schema.json
@@ -5,19 +5,13 @@
   "additionalProperties": false,
   "required": [
     "version",
-    "require_signed",
-    "authors",
-    "deployment_requirements",
-    "ff_only",
-    "notes_ref",
-    "journals_ref_prefix",
-    "anchors_ref_prefix"
+    "authors"
   ],
   "properties": {
     "schema": { "type": "string" },
     "version": {
       "type": "string",
-      "pattern": "^\\d+\\.\\d+\\.\\d+(\\-[0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*)?(\\+[0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*)?$"
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
     },
     "format_compat": { "type": "string" },
     "require_signed": { "type": "boolean" },
@@ -49,6 +43,7 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "require_signed": { "type": "boolean" },
           "require_ticket": { "type": "boolean" },
           "require_service": { "type": "boolean" },
           "require_where": {
@@ -65,15 +60,15 @@
     "ff_only": { "type": "boolean" },
     "notes_ref": {
       "type": "string",
-      "pattern": "^refs/(?!.*(?:^|/)\\.)(?!.*\\.\\.)(?!.*\\.lock$)(?!.*//@)(?!.*@\\{)(?!.*[~^:?*\\\\\[])[^\\000-\\037\\177\\s]+(?:/[^\\000-\\037\\177\\s]+)*$"
+      "pattern": "^refs/(?!.*(?:^|/)\\.)(?!.*\\.\\.)(?!.*\\.lock$)(?!.*//@)(?!.*@\\{)(?!.*[~^:?*\\[\\]\\\\])\\S+(?:/\\S+)*$"
     },
     "journals_ref_prefix": {
       "type": "string",
-      "pattern": "^refs/(?!.*(?:^|/)\\.)(?!.*\\.\\.)(?!.*\\.lock$)(?!.*//@)(?!.*@\\{)(?!.*[~^:?*\\\\\[])[^\\000-\\037\\177\\s]+(?:/[^\\000-\\037\\177\\s]+)*/$"
+      "pattern": "^refs/(?!.*(?:^|/)\\.)(?!.*\\.\\.)(?!.*\\.lock$)(?!.*//@)(?!.*@\\{)(?!.*[~^:?*\\[\\]\\\\])\\S+/(?:\\S+/)*$"
     },
     "anchors_ref_prefix": {
       "type": "string",
-      "pattern": "^refs/(?!.*(?:^|/)\\.)(?!.*\\.\\.)(?!.*\\.lock$)(?!.*//@)(?!.*@\\{)(?!.*[~^:?*\\\\\[])[^\\000-\\037\\177\\s]+(?:/[^\\000-\\037\\177\\s]+)*/$"
+      "pattern": "^refs/(?!.*(?:^|/)\\.)(?!.*\\.\\.)(?!.*\\.lock$)(?!.*//@)(?!.*@\\{)(?!.*[~^:?*\\[\\]\\\\])\\S+/(?:\\S+/)*$"
     }
   }
 }

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -1270,8 +1270,8 @@ cmd_policy() {
     require-signed)
       local val="${1:-}"; case "$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')" in 1|true|yes|on) val=true ;; 0|false|no|off) val=false ;; *) die "Usage: git shiplog policy require-signed <true|false>" ;; esac
       mkdir -p .shiplog; local policy_file=".shiplog/policy.json" tmp; tmp=$(mktemp)
-      if [ -f "$policy_file" ]; then jq --argjson rs "$val" '(.version // 1) as $v | .version=$v | .require_signed=$rs' "$policy_file" >"$tmp" 2>/dev/null || { rm -f "$tmp"; die "shiplog: failed to update $policy_file"; }
-      else printf '{"version":1,"require_signed":%s}
+      if [ -f "$policy_file" ]; then jq --arg rs "$val" --arg ver "1.0.0" '(.version // $ver) as $v | .version=$v | .require_signed=($rs|test("^(1|true|yes|on)$";"i"))' "$policy_file" >"$tmp" 2>/dev/null || { rm -f "$tmp"; die "shiplog: failed to update $policy_file"; }
+      else printf '{"version":"1.0.0","require_signed":%s}
 ' "$val" >"$tmp"; fi
       policy_install_file "$tmp" "$policy_file"
       if shiplog_can_use_bosun; then local bosun; bosun=$(shiplog_bosun_bin); "$bosun" style --title "Policy" -- "Set require_signed to $val in $policy_file"; else printf 'Set require_signed to %s in %s
@@ -1564,7 +1564,7 @@ cmd_setup() {
   esac
 
   # Start base policy
-  printf '{"version":1,"require_signed":%s}\n' "$require_signed_global" >"$tmp"
+  printf '{"version":"1.0.0","require_signed":%s}\n' "$require_signed_global" >"$tmp"
 
   # Add authors for balanced
   if [ "$strictness" = "balanced" ] && [ -n "$authors_in" ]; then
@@ -1869,11 +1869,11 @@ cmd_config() {
     mkdir -p .shiplog
     local tmp; tmp=$(mktemp)
     if [ $require_signed_global -eq 1 ]; then
-      printf '{"version":1,"require_signed":true}\n' >"$tmp"
+      printf '{"version":"1.0.0","require_signed":true}\n' >"$tmp"
     elif [ $require_signed_prod -eq 1 ]; then
-      printf '{"version":1,"require_signed":false,"deployment_requirements":{"prod":{"require_signed":true}}}\n' >"$tmp"
+      printf '{"version":"1.0.0","require_signed":false,"deployment_requirements":{"prod":{"require_signed":true}}}\n' >"$tmp"
     else
-      printf '{"version":1,"require_signed":false}\n' >"$tmp"
+      printf '{"version":"1.0.0","require_signed":false}\n' >"$tmp"
     fi
     policy_install_file "$tmp" ".shiplog/policy.json"
     if shiplog_can_use_bosun; then


### PR DESCRIPTION
- Make deployment_requirements and ff_only optional; allow per-env require_signed
- Simplify ref patterns (no control-char escapes) for AJV compatibility
- Semver string version required (writers now emit "1.0.0")

docs(policy): clarify required vs optional fields; both minimal and fuller validate

ci(policy_schema): run AJV only when policy/schema paths change; gate on failure
