### PR TITLE
fix(trust): attestation fallback for threshold=1

### DIFF
--- a/contrib/hooks/pre-receive.shiplog
+++ b/contrib/hooks/pre-receive.shiplog
@@ -229,10 +229,14 @@ enforce_trust_threshold() {
       error "trust threshold $threshold not yet enforced by hook; set SHIPLOG_ALLOW_TRUST_THRESHOLD_UNENFORCED=1 to allow temporarily"
     fi
   fi
-  # If threshold==1, allow success when commit gate satisfied or not requested. Under 'either',
-  # if commit failed, try attestation fallback.
-  if [ "$threshold" -eq 1 ] && [ "$gate" != "0" ] && [ "$gate_mode" = "either" ] && [ "$commit_checked" = "1" ] && [ "$commit_ok" != "1" ]; then
-    attestation_verify "$commit" 1 || error "no valid attestation found for threshold=1"
+  # If threshold==1 and commit verification did not succeed (or attestation mode is explicitly
+  # requested), attempt attestation verification as the decision-maker for this update.
+  # This ensures SHIPLOG_REQUIRE_SIGNED_TRUST_MODE=attestation enforces attestations even when
+  # the commit signature is absent or unaccepted.
+  if [ "$threshold" -eq 1 ]; then
+    if { [ "$commit_checked" = "1" ] && [ "$commit_ok" != "1" ]; } || [ "$gate_mode" = "attestation" ]; then
+      attestation_verify "$commit" 1 || error "no valid attestation found for threshold=1"
+    fi
   fi
 }
 

--- a/scripts/shiplog-verify-trust.sh
+++ b/scripts/shiplog-verify-trust.sh
@@ -128,15 +128,9 @@ if [ "$gate_enabled" = "1" ] || [ "$gate_enabled" = "true" ] || [ "$gate_enabled
   esac
 fi
 
-# 2) Threshold==1 is satisfied now.
-if [ "$threshold" = "1" ] || [ "$threshold" = "1.0" ]; then
-  # For threshold==1, if commit gate was enabled and checked in commit-only mode,
-  # we've already enforced it. Under 'either' mode, we may still succeed later via
-  # attestation when commit verification failed.
-  if [ "$gate_mode" != "either" ] || [ "$commit_gate_ok" = "1" ]; then
-    exit 0
-  fi
-fi
+# Note: Do not unconditionally exit for threshold==1; when sig_mode=attestation (or gate mode
+# requires attestations), we must still execute the attestation verification path even for
+# single-signature thresholds.
 
 if ! printf '%s' "$threshold" | grep -Eq '^[1-9][0-9]*$'; then
   err "invalid threshold: $threshold"

--- a/test/helpers/common.bash
+++ b/test/helpers/common.bash
@@ -236,6 +236,13 @@ shiplog_standard_teardown() {
 shiplog_write_allowed_signers_for_signing_key() {
   local out="${1:-.shiplog/allowed_signers}"
   local priv pub email domain
+  # Ensure destination directory exists
+  local out_dir
+  out_dir="$(dirname "$out")"
+  if ! mkdir -p "$out_dir"; then
+    echo "ERROR: failed to create directory for allowed_signers: $out_dir" >&2
+    return 1
+  fi
   priv="$(git config user.signingkey)"
   if [[ -z "$priv" ]]; then
     echo "ERROR: user.signingkey not configured" >&2


### PR DESCRIPTION
## Summary
- ensure attestation verification succeeds when threshold=1 and the commit gate is bypassed (attestation-only request or missing signed commit)
- adjust `scripts/shiplog-verify-trust.sh` so attestation checks happen before short-circuiting on commit signatures
- make the trust test helper create the allowed_signers parent dir so attestation fixtures work on fresh sandboxes

## Testing
- Not Run (trust hooks touched; rely on existing bats in Docker)
