### PR TITLE
fix(setup): harden remote probe errors

### DIFF
--- a/docs/features/setup.md
+++ b/docs/features/setup.md
@@ -94,6 +94,7 @@ Notes:
   - `SHIPLOG_ALLOW_MISSING_POLICY=1`
   - `SHIPLOG_ALLOW_MISSING_TRUST=1`
   See contrib/README.md for details. When `git shiplog setup` detects that these refs are missing on your remote (and auto-push is disabled), it prints this reminder so you can relax the hook until the initial push succeeds.
+- If the remote probe fails (e.g., due to timeouts or auth problems), setup now surfaces the first two trimmed stderr lines and indicates how many more lines were produced so you can act on the real failure instead of a generic status code.
 
 ## Switching Later
 

--- a/docs/features/setup.md
+++ b/docs/features/setup.md
@@ -94,7 +94,7 @@ Notes:
   - `SHIPLOG_ALLOW_MISSING_POLICY=1`
   - `SHIPLOG_ALLOW_MISSING_TRUST=1`
   See contrib/README.md for details. When `git shiplog setup` detects that these refs are missing on your remote (and auto-push is disabled), it prints this reminder so you can relax the hook until the initial push succeeds.
-- If the remote probe fails (e.g., due to timeouts or auth problems), setup now surfaces the first two trimmed stderr lines and indicates how many more lines were produced so you can act on the real failure instead of a generic status code.
+- If the remote probe fails (e.g., due to timeouts or auth problems), setup surfaces the first two trimmed stderr lines and notes how many additional lines were emitted (for example: `fatal: unable to access …; HTTP 403; (+1 more lines)`). If the underlying command produced no stderr, it falls back to a generic `command failed with exit code <n>` message (e.g., `command failed with exit code 128`) so you still learn which exit path triggered.
 
 ## Switching Later
 

--- a/test/11_pre_receive_hook.bats
+++ b/test/11_pre_receive_hook.bats
@@ -91,18 +91,11 @@ setup() {
   export SHIPLOG_AUTO_PUSH=0
   export SHIPLOG_ENV=prod
 
-  REMOTE_DIR=$(mktemp -d)
-  git init --bare "$REMOTE_DIR"
+  shiplog_use_temp_remote "$REMOTE_NAME" REMOTE_DIR
   install_hook_remote
-  git remote remove "$REMOTE_NAME" >/dev/null 2>&1 || true
-  git remote add "$REMOTE_NAME" "$REMOTE_DIR"
 }
 
 teardown() {
-  git remote remove "$REMOTE_NAME" >/dev/null 2>&1 || true
-  if [ -n "$REMOTE_DIR" ]; then
-    rm -rf "$REMOTE_DIR"
-  fi
   shiplog_cleanup_sandbox_repo
 }
 

--- a/test/11_pre_receive_hook.bats
+++ b/test/11_pre_receive_hook.bats
@@ -5,6 +5,17 @@ load helpers/common
 REMOTE_DIR=""
 REMOTE_NAME="shiplog-test"
 
+cleanup_shiplog_refs() {
+  git update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  if [ -n "$REMOTE_DIR" ] && [ -d "$REMOTE_DIR" ]; then
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  fi
+}
+
 make_entry() {
   SHIPLOG_SERVICE="hook-test" \
   SHIPLOG_STATUS="success" \
@@ -96,6 +107,7 @@ setup() {
 }
 
 teardown() {
+  cleanup_shiplog_refs
   shiplog_cleanup_sandbox_repo
 }
 

--- a/test/14_signing_failures.bats
+++ b/test/14_signing_failures.bats
@@ -71,18 +71,11 @@ JSON
   git config user.email "shiplog-tester@example.com"
   export SHIPLOG_AUTO_PUSH=0
 
-  REMOTE_DIR=$(mktemp -d)
-  git init --bare "$REMOTE_DIR"
+  shiplog_use_temp_remote "$REMOTE_NAME" REMOTE_DIR
   install_hook_remote
-  git remote remove "$REMOTE_NAME" >/dev/null 2>&1 || true
-  git remote add "$REMOTE_NAME" "$REMOTE_DIR"
 }
 
 teardown() {
-  git remote remove "$REMOTE_NAME" >/dev/null 2>&1 || true
-  if [ -n "$REMOTE_DIR" ]; then
-    rm -rf "$REMOTE_DIR"
-  fi
   shiplog_cleanup_sandbox_repo
 }
 

--- a/test/14_signing_failures.bats
+++ b/test/14_signing_failures.bats
@@ -110,10 +110,6 @@ teardown() {
   make_entry_unsigned
   run git push "$REMOTE_NAME" refs/_shiplog/journal/prod
   [ "$status" -ne 0 ]
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
 }
 
 @test "(skipped) server does not trust client-side allowed_signers" {

--- a/test/15_setup_wizard.bats
+++ b/test/15_setup_wizard.bats
@@ -87,6 +87,8 @@ teardown() {
   run git --git-dir="$ORIGIN_DIR" rev-parse --verify refs/_shiplog/policy/current
   [ "$status" -eq 0 ]
   # Cleanup
+  git --git-dir="$ORIGIN_DIR" update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
 }
 
 @test "setup strict env-driven auto-pushes trust to origin" {
@@ -114,6 +116,8 @@ teardown() {
   [ "$status" -eq 0 ]
   run git --git-dir="$ORIGIN2_DIR" rev-parse --verify refs/_shiplog/trust/root
   [ "$status" -eq 0 ]
+  git --git-dir="$ORIGIN2_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
 }
 
 @test "setup warns about missing remote refs when not auto-pushing" {
@@ -128,6 +132,8 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"SHIPLOG_ALLOW_MISSING_POLICY=1"* ]]
   [[ "$output" == *"SHIPLOG_ALLOW_MISSING_TRUST=1"* ]]
+
+  git update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
 }
 
 @test "setup does not warn when remote refs exist" {
@@ -167,6 +173,10 @@ teardown() {
   [[ "$output" != *"SHIPLOG_ALLOW_MISSING_TRUST=1"* ]]
 
   rm -f tmp/testkey.pub
+  git --git-dir="$ORIGIN_OK_DIR" update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+  git --git-dir="$ORIGIN_OK_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
 }
 
 @test "setup backups and diffs policy on overwrite" {

--- a/test/16_per_env_require_signed.bats
+++ b/test/16_per_env_require_signed.bats
@@ -40,18 +40,11 @@ JSON
   git config user.email "shiplog-tester@example.com"
   export SHIPLOG_AUTO_PUSH=0
 
-  REMOTE_DIR=$(mktemp -d)
-  git init --bare "$REMOTE_DIR"
+  shiplog_use_temp_remote "$REMOTE_NAME" REMOTE_DIR
   install_hook_remote
-  git remote remove "$REMOTE_NAME" >/dev/null 2>&1 || true
-  git remote add "$REMOTE_NAME" "$REMOTE_DIR"
 }
 
 teardown() {
-  git remote remove "$REMOTE_NAME" >/dev/null 2>&1 || true
-  if [ -n "$REMOTE_DIR" ]; then
-    rm -rf "$REMOTE_DIR"
-  fi
   shiplog_cleanup_sandbox_repo
 }
 

--- a/test/16_per_env_require_signed.bats
+++ b/test/16_per_env_require_signed.bats
@@ -45,6 +45,16 @@ JSON
 }
 
 teardown() {
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
+  if [ -n "$REMOTE_DIR" ] && [ -d "$REMOTE_DIR" ]; then
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/policy/current >/dev/null 2>&1 || true
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
+  fi
   shiplog_cleanup_sandbox_repo
 }
 
@@ -71,10 +81,14 @@ make_entry_unsigned() {
   make_entry_unsigned staging
   run git push "$REMOTE_NAME" refs/_shiplog/journal/staging
   [ "$status" -eq 0 ]
+  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
 
   # Prod unsigned should fail
   make_entry_unsigned prod
   run git push "$REMOTE_NAME" refs/_shiplog/journal/prod
   [ "$status" -ne 0 ]
   [[ "$output" == *"missing required signature"* ]]
+  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
 }

--- a/test/16_per_env_require_signed.bats
+++ b/test/16_per_env_require_signed.bats
@@ -81,14 +81,10 @@ make_entry_unsigned() {
   make_entry_unsigned staging
   run git push "$REMOTE_NAME" refs/_shiplog/journal/staging
   [ "$status" -eq 0 ]
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
 
   # Prod unsigned should fail
   make_entry_unsigned prod
   run git push "$REMOTE_NAME" refs/_shiplog/journal/prod
   [ "$status" -ne 0 ]
   [[ "$output" == *"missing required signature"* ]]
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/prod >/dev/null 2>&1 || true
 }

--- a/test/18_trust_signed_gate.bats
+++ b/test/18_trust_signed_gate.bats
@@ -40,9 +40,6 @@ install_hook_with_gate() {
   run git push -q origin refs/_shiplog/trust/root
   [ "$status" -ne 0 ]
   [[ "$output" == *"pre-receive hook declined"* ]]
-
-  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
 }
 
 @test "signed trust push passes when SHIPLOG_REQUIRE_SIGNED_TRUST=1" {
@@ -88,7 +85,4 @@ JSON
     echo "------------------------"
   fi
   [ "$status" -eq 0 ]
-
-  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
 }

--- a/test/18_trust_signed_gate.bats
+++ b/test/18_trust_signed_gate.bats
@@ -5,15 +5,10 @@ load helpers/common
 setup() {
   shiplog_standard_setup
   # Prepare a bare remote for exercising the pre-receive hook
-  REMOTE_DIR=$(mktemp -d)
-  pushd "$REMOTE_DIR" >/dev/null
-  git init -q --bare
-  popd >/dev/null
-  git remote add origin "$REMOTE_DIR"
+  shiplog_use_temp_remote origin REMOTE_DIR
 }
 
 teardown() {
-  rm -rf "$REMOTE_DIR" 2>/dev/null || true
   shiplog_standard_teardown
 }
 

--- a/test/18_trust_signed_gate.bats
+++ b/test/18_trust_signed_gate.bats
@@ -9,6 +9,12 @@ setup() {
 }
 
 teardown() {
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  if [ -n "$REMOTE_DIR" ] && [ -d "$REMOTE_DIR" ]; then
+    git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  fi
+  rm -rf .shiplog/trust_sigs >/dev/null 2>&1 || true
+  rm -f payload.txt payload.txt.sig >/dev/null 2>&1 || true
   shiplog_standard_teardown
 }
 
@@ -34,6 +40,9 @@ install_hook_with_gate() {
   run git push -q origin refs/_shiplog/trust/root
   [ "$status" -ne 0 ]
   [[ "$output" == *"pre-receive hook declined"* ]]
+
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
 }
 
 @test "signed trust push passes when SHIPLOG_REQUIRE_SIGNED_TRUST=1" {
@@ -79,4 +88,7 @@ JSON
     echo "------------------------"
   fi
   [ "$status" -eq 0 ]
+
+  git update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
+  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/trust/root >/dev/null 2>&1 || true
 }

--- a/test/19_publish_and_autopush_precedence.bats
+++ b/test/19_publish_and_autopush_precedence.bats
@@ -35,6 +35,9 @@ teardown() {
   run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "refs/_shiplog/journal/staging"
+
+  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
 }
 
 @test "auto-push honors SHIPLOG_REMOTE and bypasses pre-push hook" {

--- a/test/19_publish_and_autopush_precedence.bats
+++ b/test/19_publish_and_autopush_precedence.bats
@@ -17,10 +17,7 @@ teardown() {
   export SHIPLOG_AUTO_PUSH=0
   git config shiplog.autoPush false
   # Create a bare remote and set as origin
-  REMOTE_DIR=$(mktemp -d)
-  git remote remove origin >/dev/null 2>&1 || true
-  git init -q --bare "$REMOTE_DIR"
-  git remote add origin "$REMOTE_DIR"
+  shiplog_use_temp_remote origin REMOTE_DIR
   # Write an entry locally (no push)
   export SHIPLOG_BORING=1
   export SHIPLOG_SERVICE=pub
@@ -50,10 +47,7 @@ teardown() {
   export SHIPLOG_CLUSTER=cluster-1
   export SHIPLOG_NAMESPACE=ns-remote
   git shiplog init >/dev/null
-  REMOTE_DIR=$(mktemp -d)
-  git remote remove "$SHIPLOG_REMOTE" >/dev/null 2>&1 || true
-  git init -q --bare "$REMOTE_DIR"
-  git remote add "$SHIPLOG_REMOTE" "$REMOTE_DIR"
+  shiplog_use_temp_remote "$SHIPLOG_REMOTE" REMOTE_DIR
   cat > .git/hooks/pre-push <<'EOF'
 #!/usr/bin/env bash
 echo "hook" >> .git/prepush.log
@@ -77,7 +71,6 @@ EOF
   git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
   git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
   rm -f .git/hooks/pre-push .git/prepush.log
-  rm -rf "$REMOTE_DIR"
 }
 
 @test "publish uses SHIPLOG_REMOTE and skips pre-push hook" {
@@ -91,10 +84,7 @@ EOF
   export SHIPLOG_CLUSTER=cluster-2
   export SHIPLOG_NAMESPACE=ns-remote
   git shiplog init >/dev/null
-  REMOTE_DIR=$(mktemp -d)
-  git remote remove "$SHIPLOG_REMOTE" >/dev/null 2>&1 || true
-  git init -q --bare "$REMOTE_DIR"
-  git remote add "$SHIPLOG_REMOTE" "$REMOTE_DIR"
+  shiplog_use_temp_remote "$SHIPLOG_REMOTE" REMOTE_DIR
   cat > .git/hooks/pre-push <<'EOF'
 #!/usr/bin/env bash
 echo "hook" >> .git/prepush-publish.log
@@ -128,5 +118,4 @@ EOF
   git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
   git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
   rm -f .git/hooks/pre-push .git/prepush-publish.log
-  rm -rf "$REMOTE_DIR"
 }

--- a/test/19_publish_and_autopush_precedence.bats
+++ b/test/19_publish_and_autopush_precedence.bats
@@ -35,9 +35,6 @@ teardown() {
   run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "refs/_shiplog/journal/staging"
-
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
 }
 
 @test "auto-push honors SHIPLOG_REMOTE and bypasses pre-push hook" {
@@ -71,8 +68,6 @@ EOF
   run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "refs/_shiplog/journal/staging"
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
   rm -f .git/hooks/pre-push .git/prepush.log
 }
 
@@ -118,7 +113,5 @@ EOF
   run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "refs/_shiplog/journal/staging"
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
   rm -f .git/hooks/pre-push .git/prepush-publish.log
 }

--- a/test/19_publish_precedence.bats
+++ b/test/19_publish_precedence.bats
@@ -38,4 +38,7 @@ teardown() {
   run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
   [ "$status" -eq 0 ]
   [[ "$output" == *"refs/_shiplog/journal/staging"* ]]
+
+  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
+  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
 }

--- a/test/19_publish_precedence.bats
+++ b/test/19_publish_precedence.bats
@@ -38,7 +38,4 @@ teardown() {
   run git --git-dir="$REMOTE_DIR" for-each-ref 'refs/_shiplog/journal/staging' --format='%(refname)'
   [ "$status" -eq 0 ]
   [[ "$output" == *"refs/_shiplog/journal/staging"* ]]
-
-  git --git-dir="$REMOTE_DIR" update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
-  git update-ref -d refs/_shiplog/journal/staging >/dev/null 2>&1 || true
 }

--- a/test/19_publish_precedence.bats
+++ b/test/19_publish_precedence.bats
@@ -5,14 +5,10 @@ load helpers/common
 setup() {
   shiplog_standard_setup
   git shiplog init >/dev/null
-  REMOTE_DIR=$(mktemp -d)
-  git remote remove origin >/dev/null 2>&1 || true
-  git init -q --bare "$REMOTE_DIR"
-  git remote add origin "$REMOTE_DIR"
+  shiplog_use_temp_remote origin REMOTE_DIR
 }
 
 teardown() {
-  rm -rf -- "$REMOTE_DIR" 2>/dev/null || true
   shiplog_standard_teardown
 }
 

--- a/test/26_remote_restore.bats
+++ b/test/26_remote_restore.bats
@@ -39,15 +39,15 @@ teardown() {
   local stray_remote_dir
   stray_remote_dir=$(mktemp -d)
   git init -q --bare "$stray_remote_dir"
+  if ! git -c safe.directory="$SHIPLOG_TEST_ROOT" -C "$SHIPLOG_TEST_ROOT" remote add stray "$stray_remote_dir" >/dev/null 2>&1; then
+    rm -rf "$stray_remote_dir"
+    skip "caller repository is read-only; skipping remote restore coverage"
+  fi
   trap '(
     git -c safe.directory="'$SHIPLOG_TEST_ROOT'" -C "$SHIPLOG_TEST_ROOT" remote remove stray >/dev/null 2>&1 || true
     rm -rf "$stray_remote_dir"
   )' RETURN
   SHIPLOG_TEMP_REMOTE_DIRS+=("$stray_remote_dir")
-  (
-    cd "$SHIPLOG_TEST_ROOT" || exit 1
-    git remote add stray "$stray_remote_dir" || exit 1
-  )
 
   if [ "$ORIG_HAVE_ORIGIN" -eq 1 ]; then
     (

--- a/test/26_remote_restore.bats
+++ b/test/26_remote_restore.bats
@@ -40,7 +40,7 @@ teardown() {
   stray_remote_dir=$(mktemp -d)
   git init -q --bare "$stray_remote_dir"
   trap '(
-    cd "$SHIPLOG_TEST_ROOT" >/dev/null 2>&1 && git remote remove stray >/dev/null 2>&1 || true
+    git -c safe.directory="'$SHIPLOG_TEST_ROOT'" -C "$SHIPLOG_TEST_ROOT" remote remove stray >/dev/null 2>&1 || true
     rm -rf "$stray_remote_dir"
   )' RETURN
   SHIPLOG_TEMP_REMOTE_DIRS+=("$stray_remote_dir")

--- a/test/26_remote_restore.bats
+++ b/test/26_remote_restore.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+REMOTE_RESTORE_SKIPPED=0
+ORIG_REMOTE_LIST=""
+ORIG_ORIGIN_URLS=""
+ORIG_ORIGIN_FETCHES=""
+ORIG_ORIGIN_PUSHURLS=""
+ORIG_HAVE_ORIGIN=0
+
+setup() {
+  shiplog_standard_setup
+  ORIG_REMOTE_LIST=$(git remote)
+  if git remote | grep -qx origin; then
+    ORIG_HAVE_ORIGIN=1
+    ORIG_ORIGIN_URLS=$(git config --get-all remote.origin.url 2>/dev/null || printf '')
+    ORIG_ORIGIN_FETCHES=$(git config --get-all remote.origin.fetch 2>/dev/null || printf '')
+    ORIG_ORIGIN_PUSHURLS=$(git config --get-all remote.origin.pushurl 2>/dev/null || printf '')
+  else
+    ORIG_HAVE_ORIGIN=0
+    ORIG_ORIGIN_URLS=""
+    ORIG_ORIGIN_FETCHES=""
+    ORIG_ORIGIN_PUSHURLS=""
+  fi
+}
+
+teardown() {
+  if [ "$REMOTE_RESTORE_SKIPPED" -eq 0 ]; then
+    shiplog_standard_teardown
+  else
+    # Ensure global env tracking resets for subsequent files
+    REMOTE_RESTORE_SKIPPED=0
+  fi
+}
+
+@test "sandbox teardown restores caller remote configuration" {
+  # Mutate caller remotes directly to simulate an unsafe test
+  local stray_remote_dir
+  stray_remote_dir=$(mktemp -d)
+  git init -q --bare "$stray_remote_dir"
+  SHIPLOG_TEMP_REMOTE_DIRS+=("$stray_remote_dir")
+  git -C "$SHIPLOG_TEST_ROOT" remote add stray "$stray_remote_dir"
+
+  if [ "$ORIG_HAVE_ORIGIN" -eq 1 ]; then
+    git -C "$SHIPLOG_TEST_ROOT" config --add remote.origin.fetch '+refs/tags/*:refs/remotes/origin/tags'
+    git -C "$SHIPLOG_TEST_ROOT" config --add remote.origin.pushurl 'ssh://example/push'
+    git -C "$SHIPLOG_TEST_ROOT" config --add remote.origin.url 'ssh://example/extra'
+  fi
+
+  REMOTE_RESTORE_SKIPPED=1
+  shiplog_standard_teardown
+
+  # Verify remotes restored to their pre-test state
+  local current_remotes
+  current_remotes=$(git remote)
+  [ "$current_remotes" = "$ORIG_REMOTE_LIST" ]
+
+  if [ "$ORIG_HAVE_ORIGIN" -eq 1 ]; then
+    run git config --get-all remote.origin.url
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ORIG_ORIGIN_URLS" ]
+
+    run git config --get-all remote.origin.fetch
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ORIG_ORIGIN_FETCHES" ]
+
+    run git config --get-all remote.origin.pushurl
+    if [ -n "$ORIG_ORIGIN_PUSHURLS" ]; then
+      [ "$status" -eq 0 ]
+      [ "$output" = "$ORIG_ORIGIN_PUSHURLS" ]
+    else
+      [ "$status" -ne 0 ]
+    fi
+  else
+    run bash -c 'git remote | grep -qx origin'
+    [ "$status" -ne 0 ]
+  fi
+}

--- a/test/README.md
+++ b/test/README.md
@@ -22,6 +22,14 @@ The `test/` directory contains the Bats-based integration suite that exercises t
 - The entrypoint installs `bin/git-shiplog` into `/usr/local/bin/git-shiplog` and exports `SHIPLOG_BOSUN_BIN`, then runs Bats (`bats -r`).
 - Each Bats file calls `load helpers/common`, whose `shiplog_install_cli` helper ensures the CLI is present and executable before tests begin.
 
+## Test Author Checklist
+
+- **Sandbox first**: in `setup()`, call `shiplog_standard_setup` (or at minimum `shiplog_use_sandbox_repo`) so every test operates inside a disposable repo. Never hit the developer’s working tree.
+- **Temporary remotes**: use `shiplog_use_temp_remote <name> [var]` instead of `git remote add`. The helper creates a bare temp repo, registers it, and the teardown plumbing deletes it safely.
+- **Ref hygiene**: if your test creates or pushes `refs/_shiplog/*`, delete those refs (locally and in any temp remotes) before teardown. Shared helpers like `cleanup_*_refs` are provided for common suites.
+- **Environment restore**: shared helpers snapshot `PATH` and key `SHIPLOG_*` vars; if you introduce additional env/config mutations, capture and restore them so later tests start clean.
+- **Document helpers**: when you add a new helper or pattern, update this README or inline comments in `test/helpers/common.bash` so future contributors reuse it.
+
 ## Adding or Updating Tests
 1. Create a new `*.bats` file or update an existing one under `test/`.
 2. Reuse shared setup logic via `load helpers/common` and environment variables (`SHIPLOG_*`) rather than duplicating installation code.

--- a/test/helpers/common.bash
+++ b/test/helpers/common.bash
@@ -194,6 +194,8 @@ shiplog_standard_env_begin() {
 }
 
 shiplog_use_temp_remote() {
+# Helper documentation: ensures remote creation happens via throw-away bare
+# repos that the harness cleans up. Always call after shiplog_use_sandbox_repo.
   local remote="${1:-origin}"
   local __var="${2:-}"
   local dir
@@ -229,6 +231,9 @@ shiplog_use_temp_remote() {
 }
 
 shiplog_install_cli() {
+# Install git-shiplog into a writable bin directory (preferring /usr/local/bin)
+# and export SHIPLOG_HOME so tests reference the baked snapshot of the project.
+# Required for every Bats test bundle.
   local project_home="${SHIPLOG_HOME:-$SHIPLOG_PROJECT_ROOT}"
 
   if [[ ! -f "${project_home}/bin/git-shiplog" ]]; then
@@ -265,6 +270,8 @@ shiplog_install_cli() {
 }
 
 shiplog_clone_sandbox_repo() {
+# Clone the public testing sandbox repo into $1 (used when
+# SHIPLOG_USE_LOCAL_SANDBOX=0).
   local dest="$1"
   git clone -q "$SHIPLOG_SANDBOX_REPO" "$dest"
   (
@@ -276,6 +283,8 @@ shiplog_clone_sandbox_repo() {
 }
 
 shiplog_use_sandbox_repo() {
+# Create or clone a sandbox repo, cd into it, and snapshot the caller’s remote
+# configuration for later restoration.
   local dest
   dest="${1:-}"
   shiplog_snapshot_caller_repo_state
@@ -308,6 +317,8 @@ shiplog_use_sandbox_repo() {
 }
 
 shiplog_cleanup_sandbox_repo() {
+# Return to the original working tree, delete the sandbox repo, clean temp
+# remotes, and restore the caller repo remotes.
   cd "$SHIPLOG_TEST_ROOT"
   if [[ -n "${SHIPLOG_SANDBOX_DIR:-}" && -d "$SHIPLOG_SANDBOX_DIR" ]]; then
     rm -rf "$SHIPLOG_SANDBOX_DIR"


### PR DESCRIPTION
## Summary
- sanitize remote probe errors so hints always have content
- fall back to a generic exit-code message when git ls-remote is silent

## Testing
- make test