### PR TITLE
feat: Deployment ID + replay wrapper + anchors; docs+tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,27 @@ git shiplog config --interactive --emit-github-workflow
 
 ---
 
+## Customization
+
+- Preamble (run): wrap live command output with a start/end marker on TTYs.
+  - Enable per‑invocation: `git shiplog run --preamble -- …`
+  - Enable globally: `git config shiplog.preamble true` (or `SHIPLOG_PREAMBLE=1`)
+  - Defaults: Start `🚢🪵🎬`, End `🚢🪵✅` (success) / `🚢🪵❌` (failure)
+  - Override text: `SHIPLOG_PREAMBLE_START_TEXT`, `SHIPLOG_PREAMBLE_END_TEXT`, `SHIPLOG_PREAMBLE_END_TEXT_FAIL`
+
+- Confirmation glyph (after write): one‑line success indicator
+  - Default: `🚢🪵⚓️` when an anchor exists; otherwise `🚢🪵✅`
+  - Override: `SHIPLOG_CONFIRM_TEXT="…"`
+  - Suppress: `SHIPLOG_QUIET_ON_SUCCESS=1`
+
+- Auto‑push behavior
+  - Default: auto‑push is on and uses `git push --no-verify` to avoid pre‑push hooks during deployments.
+  - Disable per‑run: `--no-push` (or `SHIPLOG_AUTO_PUSH=0`); publish later with `git shiplog publish` (also uses `--no-verify`).
+
+See also: docs/reference/env.md for a complete list of environment variables and config toggles.
+
+---
+
 ## How It Works: Ref Structure
 
 Shiplog stores all its data in lightweight Git refs, separate from your main code branches.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ See also: docs/reference/env.md for a complete list of environment variables and
 
 ---
 
+## Deployments & Replay
+
+- Stamp a first‑class Deployment ID
+  - One session:
+    - eval "$(scripts/shiplog-deploy-id.sh --export)"
+    - Every `run`/`write`/`append` will include `deployment.id="$SHIPLOG_DEPLOY_ID"`.
+  - One‑off per command: pass `--deployment <ID>`.
+  - Back‑compat: if `--ticket` is omitted, the ID mirrors into `why.ticket`.
+
+- Replay the deployment
+  - scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID" --step
+  - Or filter by legacy ticket: `--ticket <ID>`.
+  - Range/speed/step options are documented under docs/features/replay.md and docs/commands/replay.md.
+
+---
+
 ## How It Works: Ref Structure
 
 Shiplog stores all its data in lightweight Git refs, separate from your main code branches.

--- a/README.md
+++ b/README.md
@@ -154,9 +154,14 @@ See also: docs/reference/env.md for a complete list of environment variables and
   - Back‑compat: if `--ticket` is omitted, the ID mirrors into `why.ticket`.
 
 - Replay the deployment
-  - scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID" --step
-  - Or filter by legacy ticket: `--ticket <ID>`.
-  - Range/speed/step options are documented under docs/features/replay.md and docs/commands/replay.md.
+  - Durable by ID: `git shiplog replay --env prod --deployment "$SHIPLOG_DEPLOY_ID" --step`
+  - Durable by anchor: `git shiplog replay --env prod --since-anchor`
+  - Operator convenience: `git shiplog replay --pointer refs/_shiplog/deploy/prod` (uses local reflog)
+  - Under the hood script: `scripts/shiplog-replay.sh` (same options)
+  - See docs/features/replay.md and docs/commands/replay.md for details.
+
+Related commands
+- Anchors: `git shiplog anchor set|show|list` (docs/commands/anchor.md)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Trust Bootstrap and Enforcement](TRUST.md)
 - [Feature Guides](features)
   - [Config Wizard](features/config.md)
+  - [Replay (experimental)](features/replay.md)
 - [Structured Entry Schema](reference/json-schema.md)
 - [Environment & Config Reference](reference/env.md)
 - Release Notes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@
 - [Plugin Hooks](plugins.md)
 - Git Hosts & Enforcement:
   - [Hosting Matrix](hosting/matrix.md)
-  - [GitHub and Shiplog Refs](hosting/github.md)
+ - [GitHub and Shiplog Refs](hosting/github.md)
  - Commands:
    - [Replay (experimental)](commands/replay.md)
    - [Mint Deployment IDs](commands/deploy-id.md)
+   - [Anchors](commands/anchor.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@
   - [v0.2.0](releases/v0.2.0.md)
 - [Bosun Helpers](bosun)
 - [Plugin Hooks](plugins.md)
- - Git Hosts & Enforcement:
-   - [Hosting Matrix](hosting/matrix.md)
-   - [GitHub and Shiplog Refs](hosting/github.md)
+- Git Hosts & Enforcement:
+  - [Hosting Matrix](hosting/matrix.md)
+  - [GitHub and Shiplog Refs](hosting/github.md)
+ - Commands:
+   - [Replay (experimental)](commands/replay.md)
+   - [Mint Deployment IDs](commands/deploy-id.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Feature Guides](features)
   - [Config Wizard](features/config.md)
 - [Structured Entry Schema](reference/json-schema.md)
+- [Environment & Config Reference](reference/env.md)
 - Release Notes:
   - [v0.4.0-alpha](releases/v0.4.0-alpha.md)
   - [v0.2.1](releases/v0.2.1.md)

--- a/docs/commands/anchor.md
+++ b/docs/commands/anchor.md
@@ -1,0 +1,29 @@
+# git shiplog anchor
+
+Anchors are durable replay boundaries per environment. They live under `refs/_shiplog/anchors/<env>` and can be pushed/fetched like any other ref. Use them with `git shiplog replay --since-anchor` to page through entries since the last anchor.
+
+## Usage
+
+```bash
+git shiplog anchor set  --env prod [--ref <sha>] [--reason "text"]
+git shiplog anchor show --env prod [--json]
+git shiplog anchor list --env prod
+```
+
+## Subcommands
+
+- `set` — Move the env’s anchor to a commit (default: the journal tip for ENV). Writes a reflog entry with your reason.
+- `show` — Print the current anchor value. Use `--json` for machine-readable output.
+- `list` — Show the anchor’s reflog (the history of moves), including your reasons.
+
+## Why Anchors?
+
+- Portable: Anchors are refs committed to Git; they sync across clones.
+- Replay-friendly: `git shiplog replay --since-anchor` replays entries created since the last anchor.
+- Audit trail: Each `set` records a reflog entry (tip: keep reflogs around longer via repo config if desired).
+
+## See Also
+
+- `git shiplog replay --since-anchor` — Anchor-aware replay.
+- `docs/features/replay.md` — Additional replay examples.
+

--- a/docs/commands/deploy-id.md
+++ b/docs/commands/deploy-id.md
@@ -1,0 +1,33 @@
+# shiplog-deploy-id
+
+Generate a sortable Deployment ID and optionally export it for the current shell so that every subsequent Shiplog entry is stamped with the same ID.
+
+## Usage
+
+```bash
+# Print an ID (ULID if available; else UUID; else timestamp+sha fallback)
+scripts/shiplog-deploy-id.sh
+
+# Export it into your shell for this session
+eval "$(scripts/shiplog-deploy-id.sh --export)"
+
+# Now stamp every step of your deployment automatically
+git shiplog run --service web -- bash -lc 'prechecks'
+git shiplog run --service web -- bash -lc 'rollout'
+git shiplog write --service web --status finalize --reason "done"
+
+# Replay just those entries later
+scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID" --step
+```
+
+## Options
+
+- `--export|-x` — Print `export SHIPLOG_DEPLOY_ID=<id>` so you can `eval` it.
+- `--id <value>` — Provide your own ID (skips minting).
+- `--help` — Show usage.
+
+## Notes
+
+- The Deployment ID is also mirrored into `why.ticket` when you don’t provide a ticket, for backward compatibility with existing consumers.
+- You can also pass a Deployment ID directly on any `run/write/append` via `--deployment <id>`.
+

--- a/docs/commands/replay.md
+++ b/docs/commands/replay.md
@@ -1,22 +1,19 @@
-# shiplog-replay (experimental)
+# git shiplog replay (wrapper) and shiplog-replay (script)
 
 Replays Shiplog entries as a linear “story” for a given environment, deployment ID, or range. Prints a concise header for each entry, optional trailer JSON, and any attached log note (paced by recorded durations).
 
 ## Usage
 
 ```bash
-# Last 5 entries in prod, roughly real time
-scripts/shiplog-replay.sh --env prod
+# First-class command (preferred):
+git shiplog replay --deployment "$SHIPLOG_DEPLOY_ID" --env prod --step
+git shiplog replay --since-anchor --env prod
+git shiplog replay --pointer refs/_shiplog/deploy/prod --env prod
+git shiplog replay --tag deploy/prod --env prod
 
-# Fast replay (no sleeps) of the last 10 entries
-scripts/shiplog-replay.sh --env staging --count 10 --speed 0
-
-# Step through a specific window (inclusive)
+# Under the hood: the wrapper delegates to the script
+scripts/shiplog-replay.sh --env prod --count 10 --speed 0
 scripts/shiplog-replay.sh --env prod --from <old-sha> --to <new-sha> --step
-
-# Replay just one deployment by ID (or ticket)
-scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID"
-# alias: --ticket <id>
 ```
 
 ## Options
@@ -29,6 +26,9 @@ scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID"
 - `--compact`: Print only the header (omit trailer JSON).
 - `--no-notes`: Do not print attached logs.
 - `--deployment <id>`: Filter to entries with `deployment.id=<id>` (or legacy `why.ticket=<id>`). Alias: `--ticket <id>`.
+- `--since-anchor`: Use the last anchor as start and the current journal tip as end.
+- `--pointer <ref>`: Use `<ref>@{1}..@{0}` as the window (local reflog convenience).
+- `--tag <name>`: Shortcut for `--pointer refs/tags/<name>`.
 
 ## Notes
 
@@ -40,4 +40,3 @@ scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID"
 
 - `docs/features/replay.md` — Additional examples and behavior details.
 - `scripts/shiplog-deploy-id.sh` — Mint a sortable Deployment ID.
-

--- a/docs/commands/replay.md
+++ b/docs/commands/replay.md
@@ -1,0 +1,43 @@
+# shiplog-replay (experimental)
+
+Replays Shiplog entries as a linear “story” for a given environment, deployment ID, or range. Prints a concise header for each entry, optional trailer JSON, and any attached log note (paced by recorded durations).
+
+## Usage
+
+```bash
+# Last 5 entries in prod, roughly real time
+scripts/shiplog-replay.sh --env prod
+
+# Fast replay (no sleeps) of the last 10 entries
+scripts/shiplog-replay.sh --env staging --count 10 --speed 0
+
+# Step through a specific window (inclusive)
+scripts/shiplog-replay.sh --env prod --from <old-sha> --to <new-sha> --step
+
+# Replay just one deployment by ID (or ticket)
+scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID"
+# alias: --ticket <id>
+```
+
+## Options
+
+- `--env <name>`: Journal environment (default: `prod` or `SHIPLOG_ENV`).
+- `--from <sha>` / `--to <sha>`: Inclusive range; accepts refs.
+- `--count <n>`: Limit the number of entries (default 5; ignored when `--deployment` set).
+- `--speed <x>`: Pacing multiplier (1.0 ≈ real time; 0 = no sleeps).
+- `--step`: Wait for Enter between entries instead of sleeping.
+- `--compact`: Print only the header (omit trailer JSON).
+- `--no-notes`: Do not print attached logs.
+- `--deployment <id>`: Filter to entries with `deployment.id=<id>` (or legacy `why.ticket=<id>`). Alias: `--ticket <id>`.
+
+## Notes
+
+- Read-only: this helper does not modify refs.
+- Pacing is approximated uniformly across the log when a run duration is present.
+- Requires `jq` and `git`.
+
+## See Also
+
+- `docs/features/replay.md` — Additional examples and behavior details.
+- `scripts/shiplog-deploy-id.sh` — Mint a sortable Deployment ID.
+

--- a/docs/features/append.md
+++ b/docs/features/append.md
@@ -1,0 +1,41 @@
+# Append Command
+
+## Summary
+`git shiplog append` records a deployment entry non-interactively by merging a JSON object you supply (from CLI, file, or stdin) into the Shiplog trailer. It runs `write` under the hood in boring/auto-confirm mode, honoring the same metadata flags and policy checks.
+
+## Usage
+```bash
+# Merge JSON from stdin and set required metadata via flags
+printf '{"checks":{"canary":"green"}}' | \
+  git shiplog append --service deploy --status success --json -
+
+# Merge from a file and stamp a Deployment ID
+git shiplog append --service web --status success \
+  --json-file payload.json --deployment REL-2025-10-30.1
+```
+
+## Flags and Behavior
+- Accepts the same context flags as `write` (`--service`, `--status`, `--reason`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--image`, `--tag`, `--run-url`, `--log`/`--attach`, `--env`).
+- `--json` or `--json-file` must supply a JSON object; it is merged at the top level of the trailer.
+- `--deployment <id>` (or `SHIPLOG_DEPLOY_ID`) adds `deployment.id = "<id>"`. If `--ticket` is omitted, the ID is mirrored to `why.ticket` for compatibility.
+- `--log PATH` (alias `--attach PATH`) attaches an NDJSON note.
+- `--dry-run` previews without writing.
+
+## Examples
+```bash
+# Attach a run URL and canary result
+git shiplog append --service api --status success \
+  --run-url https://ci.example/run/42 \
+  --json '{"checks":{"canary":"green"}}'
+
+# Append with a Deployment ID and a ticket
+git shiplog append --service api --status in_progress \
+  --ticket OPS-4242 --deployment REL-2025-10-30.1 \
+  --json '{"stage":"migrate"}'
+```
+
+## See Also
+- `docs/features/write.md`
+- `docs/features/run.md`
+- `docs/features/command-reference.md`
+- `docs/features/replay.md`

--- a/docs/features/command-reference.md
+++ b/docs/features/command-reference.md
@@ -39,14 +39,14 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
   - Usage:
     - Interactive: `git shiplog write prod`
     - Non-interactive: `SHIPLOG_BORING=1 git shiplog --yes write prod`
-  - Env: `SHIPLOG_SERVICE`, `SHIPLOG_STATUS`, `SHIPLOG_REASON`, `SHIPLOG_TICKET`, `SHIPLOG_REGION`, `SHIPLOG_CLUSTER`, `SHIPLOG_NAMESPACE`, `SHIPLOG_IMAGE`, `SHIPLOG_TAG`, `SHIPLOG_RUN_URL`, `SHIPLOG_LOG`, `SHIPLOG_AUTO_PUSH`.
+  - Env: `SHIPLOG_SERVICE`, `SHIPLOG_STATUS`, `SHIPLOG_REASON`, `SHIPLOG_TICKET`, `SHIPLOG_DEPLOY_ID`, `SHIPLOG_REGION`, `SHIPLOG_CLUSTER`, `SHIPLOG_NAMESPACE`, `SHIPLOG_IMAGE`, `SHIPLOG_TAG`, `SHIPLOG_RUN_URL`, `SHIPLOG_LOG`, `SHIPLOG_AUTO_PUSH`.
   - Flags: accepts `--dry-run` to preview the entry after prompts without appending to the journal or pushing notes.
   - Effects: honors allowlists/signing per policy; pushes journal (+notes) to origin unless disabled.
 
 - `append [OPTIONS]`
   - Purpose: append a new entry non-interactively by supplying a JSON payload via CLI, stdin, or file.
   - Usage: `printf '{"deployment":"green"}' | git shiplog append --service deploy --status success --json -`
-  - Flags: mirrors `write` (`--service`, `--status`, `--reason`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--image`, `--tag`, `--run-url`, `--log`, `--env`, `--dry-run`).
+  - Flags: mirrors `write` (`--service`, `--status`, `--reason`, `--ticket`, `--deployment`, `--region`, `--cluster`, `--namespace`, `--image`, `--tag`, `--run-url`, `--log`, `--env`, `--dry-run`).
   - Notes: sets `SHIPLOG_EXTRA_JSON` automatically with the provided object and runs `write` in boring/auto-confirm mode.
 
 - `run [OPTIONS] -- <command ...>`
@@ -54,8 +54,8 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
   - Usage:
     - Success case: `git shiplog run --service deploy --reason "Smoke test" -- env printf hi`
     - Failure case: `git shiplog run --service deploy --status-failure failed -- false`
-  - Flags: `--service`, `--reason`, `--status-success`, `--status-failure`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--env`, `--dry-run`.
-  - Notes: captures stdout/stderr to a temporary log that is attached as a git note (skipped if empty) and merges `{run:{...}}` into the JSON trailer via `SHIPLOG_EXTRA_JSON`. Prints a one‑line confirmation after the run (default `🚢🪵⚓️` when an anchor exists or `🚢🪵✅` otherwise); override via `SHIPLOG_CONFIRM_TEXT` or suppress with `SHIPLOG_QUIET_ON_SUCCESS=1`. Optional console preamble can be enabled with `--preamble` or `SHIPLOG_PREAMBLE=1`. `--dry-run` prints what would execute and exits without running or writing. See `docs/features/run.md`.
+  - Flags: `--service`, `--reason`, `--status-success`, `--status-failure`, `--ticket`, `--deployment`, `--region`, `--cluster`, `--namespace`, `--env`, `--dry-run`.
+  - Notes: captures stdout/stderr to a temporary log that is attached as a git note (skipped if empty) and merges `{run:{...}}` into the JSON trailer via `SHIPLOG_EXTRA_JSON`. Prints a one‑line confirmation after the run (default `🚢🪵⚓️` when an anchor exists or `🚢🪵✅` otherwise); override via `SHIPLOG_CONFIRM_TEXT` or suppress with `SHIPLOG_QUIET_ON_SUCCESS=1`. Optional console preamble can be enabled with `--preamble` or `SHIPLOG_PREAMBLE=1`. `--deployment <id>` stamps `deployment.id` and mirrors to `why.ticket` when unset. `--dry-run` prints what would execute and exits without running or writing. See `docs/features/run.md`.
 
 - `ls [ENV] [LIMIT]`
   - Purpose: list recent entries.

--- a/docs/features/command-reference.md
+++ b/docs/features/command-reference.md
@@ -55,7 +55,7 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
     - Success case: `git shiplog run --service deploy --reason "Smoke test" -- env printf hi`
     - Failure case: `git shiplog run --service deploy --status-failure failed -- false`
   - Flags: `--service`, `--reason`, `--status-success`, `--status-failure`, `--ticket`, `--region`, `--cluster`, `--namespace`, `--env`, `--dry-run`.
-  - Notes: captures stdout/stderr to a temporary log that is attached as a git note (skipped if empty) and merges `{run:{...}}` into the JSON trailer via `SHIPLOG_EXTRA_JSON`. Prints a minimal confirmation after the run (default `🪵`), configurable via `SHIPLOG_CONFIRM_TEXT`. `--dry-run` prints the command that would execute and exits without running it or writing a journal entry. See `docs/features/run.md` for details.
+  - Notes: captures stdout/stderr to a temporary log that is attached as a git note (skipped if empty) and merges `{run:{...}}` into the JSON trailer via `SHIPLOG_EXTRA_JSON`. Prints a one‑line confirmation after the run (default `🚢🪵⚓️` when an anchor exists or `🚢🪵✅` otherwise); override via `SHIPLOG_CONFIRM_TEXT` or suppress with `SHIPLOG_QUIET_ON_SUCCESS=1`. Optional console preamble can be enabled with `--preamble` or `SHIPLOG_PREAMBLE=1`. `--dry-run` prints what would execute and exits without running or writing. See `docs/features/run.md`.
 
 - `ls [ENV] [LIMIT]`
   - Purpose: list recent entries.
@@ -88,7 +88,7 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
 - `publish [ENV] [--no-notes] [--policy] [--trust] [--all]`
   - Purpose: push Shiplog refs (journals/notes, and optionally policy/trust) to origin without writing a new entry.
   - Usage: `git shiplog publish` (current env), `git shiplog publish --env prod`, `git shiplog publish --all --policy`
-  - Notes: use this at the end of a deployment if you disable auto-push. Precedence for pushing: command flags > `git config shiplog.autoPush` > `SHIPLOG_AUTO_PUSH`.
+  - Notes: use this at the end of a deployment if you disable auto-push. Precedence for pushing: command flags > `git config shiplog.autoPush` > `SHIPLOG_AUTO_PUSH`. Shiplog uses `git push --no-verify` to avoid pre‑push hooks by design.
 
 - `policy [show|validate|require-signed|toggle] [--json] [--boring]`
   - Purpose: inspect/change effective policy and signing requirement.

--- a/docs/features/command-reference.md
+++ b/docs/features/command-reference.md
@@ -85,10 +85,28 @@ A concise, code-sourced reference for Shiplog commands, flags, and examples. Glo
   - Usage: `git shiplog export-json prod | jq '.'`
   - Requires: `jq`.
 
+- `replay [OPTIONS]`
+  - Purpose: Replay journal entries. Wrapper around `scripts/shiplog-replay.sh` with convenience sources.
+  - Usage:
+    - Durable by ID: `git shiplog replay --env prod --deployment "$SHIPLOG_DEPLOY_ID" --step`
+    - Durable by anchor: `git shiplog replay --env prod --since-anchor`
+    - Pointer (local reflog): `git shiplog replay --pointer refs/_shiplog/deploy/prod --env prod`
+    - Tag (best-effort): `git shiplog replay --tag deploy/prod --env prod`
+  - Flags: `--env`, `--from`, `--to`, `--count`, `--speed`, `--step`, `--no-notes`, `--compact`, `--deployment`, `--ticket`, `--since-anchor`, `--pointer`, `--tag`.
+  - Notes: prefers portable sources (`--deployment`, `--since-anchor`). Pointer/tag rely on local reflogs.
+
 - `publish [ENV] [--no-notes] [--policy] [--trust] [--all]`
   - Purpose: push Shiplog refs (journals/notes, and optionally policy/trust) to origin without writing a new entry.
   - Usage: `git shiplog publish` (current env), `git shiplog publish --env prod`, `git shiplog publish --all --policy`
   - Notes: use this at the end of a deployment if you disable auto-push. Precedence for pushing: command flags > `git config shiplog.autoPush` > `SHIPLOG_AUTO_PUSH`. Shiplog uses `git push --no-verify` to avoid pre‑push hooks by design.
+
+- `anchor set|show|list`
+  - Purpose: manage durable replay boundaries for an environment.
+  - Usage:
+    - Set: `git shiplog anchor set --env prod [--ref <sha>] [--reason "text"]`
+    - Show: `git shiplog anchor show --env prod [--json]`
+    - List: `git shiplog anchor list --env prod`
+  - Notes: anchors live under `refs/_shiplog/anchors/<env>` and are used by `git shiplog replay --since-anchor`.
 
 - `policy [show|validate|require-signed|toggle] [--json] [--boring]`
   - Purpose: inspect/change effective policy and signing requirement.

--- a/docs/features/export-json.md
+++ b/docs/features/export-json.md
@@ -13,6 +13,25 @@ git shiplog export-json [ENV] | jq '.'
 - Streams commits in reverse chronological order and appends a `commit` field to each JSON payload.
 - Uses the same environment resolution rules as other commands (argument, `--env`, `SHIPLOG_ENV`, default `prod`).
 
+## Filtering by Deployment ID or Ticket
+
+```bash
+# All commits for a given deployment id (preferred)
+DEPLOY_ID="REL-2025-10-30.1"
+git shiplog export-json prod \
+  | jq -r --arg id "$DEPLOY_ID" 'select((.deployment.id // "") == $id) | .commit'
+
+# Back-compat by ticket
+git shiplog export-json prod \
+  | jq -r --arg id "$DEPLOY_ID" 'select((.why.ticket // "") == $id) | .commit'
+```
+
+Tip: pass these through the replay command to “page” a deployment:
+
+```bash
+git shiplog replay --env prod --deployment "$DEPLOY_ID" --step
+```
+
 ## Related Code
 - `lib/commands.sh` — `cmd_export_json()`
 

--- a/docs/features/replay.md
+++ b/docs/features/replay.md
@@ -44,6 +44,12 @@ scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID" --speed 0
 - `--step` — Step through entries interactively.
 - `--deployment <id>` — Replay only entries stamped with `deployment.id=<id>` (or with back‑compat `why.ticket=<id>`). Alias: `--ticket <id>`.
 
+## Convenience Sources
+
+- `--since-anchor` (portable): use the last anchor for the environment as the start boundary and the current journal tip as the end.
+- `--pointer <ref>` (local convenience): resolve `<ref>@{1}..@{0}` from the local reflog; handy for a “last deployment” pointer like `refs/_shiplog/deploy/prod`.
+- `--tag <name>`: equivalent to `--pointer refs/tags/<name>` and depends on tag reflogs.
+
 ## Notes & Limitations
 
 - Logs attached as git notes are printed as saved; per-line timestamps aren’t preserved, so intra-log pacing is approximated uniformly.

--- a/docs/features/replay.md
+++ b/docs/features/replay.md
@@ -16,6 +16,10 @@ scripts/shiplog-replay.sh --env prod --from <old-sha> --to <new-sha> --step
 
 # Compact mode (no trailer JSON), suppress logs
 scripts/shiplog-replay.sh --env prod --count 20 --compact --no-notes
+
+# Replay a specific deployment by ID (or ticket)
+scripts/shiplog-replay.sh --env prod --deployment "$SHIPLOG_DEPLOY_ID" --speed 0
+# alias: --ticket <id>
 ```
 
 ## Behavior
@@ -38,6 +42,7 @@ scripts/shiplog-replay.sh --env prod --count 20 --compact --no-notes
 - `--no-notes` — Do not print attached logs.
 - `--compact` — Do not print the trailer JSON, only the entry header.
 - `--step` — Step through entries interactively.
+- `--deployment <id>` — Replay only entries stamped with `deployment.id=<id>` (or with back‑compat `why.ticket=<id>`). Alias: `--ticket <id>`.
 
 ## Notes & Limitations
 
@@ -50,4 +55,3 @@ scripts/shiplog-replay.sh --env prod --count 20 --compact --no-notes
 - `git shiplog ls`, `git shiplog show` — inspect individual entries.
 - `git shiplog export-json` — stream trailer JSONs as NDJSON for custom tooling.
 - `docs/features/run.md` — structured `run` payload captured by `git shiplog run`.
-

--- a/docs/features/replay.md
+++ b/docs/features/replay.md
@@ -1,0 +1,53 @@
+# Replay (Experimental)
+
+`scripts/shiplog-replay.sh` replays a sequence of Shiplog entries from a journal and prints their summaries and (optionally) attached logs. This is useful when you want to review a deployment that involved multiple steps and watch the captured output in order.
+
+## TL;DR
+
+```bash
+# Last 5 entries in prod, paced by recorded durations
+scripts/shiplog-replay.sh --env prod
+
+# Fastest replay (no sleeps) of the last 10 entries in staging
+scripts/shiplog-replay.sh --env staging --count 10 --speed 0
+
+# Step through a specific range (inclusive), showing logs
+scripts/shiplog-replay.sh --env prod --from <old-sha> --to <new-sha> --step
+
+# Compact mode (no trailer JSON), suppress logs
+scripts/shiplog-replay.sh --env prod --count 20 --compact --no-notes
+```
+
+## Behavior
+
+- Prints a concise header for each entry with `service`, `env`, `status`, `seq`, timestamp, author, and repo head.
+- When available, prints the JSON trailer (`jq -C -S .`) so you can see the structured fields captured for each entry.
+- If a git note (log) is attached, prints it between `--- log (notes) ---` and `--- end log ---`.
+- Paces output using the recorded run duration (when present) and a `--speed` multiplier.
+  - `--speed 1.0` (default): roughly real time, capped to short sleeps between entries.
+  - `--speed 0`: fastest replay (no sleeps).
+- `--step` pauses between entries and waits for Enter instead of sleeping.
+
+## Options
+
+- `--env <name>` — Journal environment (default: `prod` or `SHIPLOG_ENV`).
+- `--from <sha>` — Start at this commit (inclusive). If omitted, starts at the latest.
+- `--to <sha>` — Stop at this commit (inclusive).
+- `--count <n>` — Maximum number of entries (default `5`).
+- `--speed <x>` — Speed multiplier for pacing (`1.0` = real time-ish, `0` = fastest).
+- `--no-notes` — Do not print attached logs.
+- `--compact` — Do not print the trailer JSON, only the entry header.
+- `--step` — Step through entries interactively.
+
+## Notes & Limitations
+
+- Logs attached as git notes are printed as saved; per-line timestamps aren’t preserved, so intra-log pacing is approximated uniformly.
+- This helper is read-only; it does not modify Shiplog refs or your repository state.
+- Requires `jq` and `git`.
+
+## See Also
+
+- `git shiplog ls`, `git shiplog show` — inspect individual entries.
+- `git shiplog export-json` — stream trailer JSONs as NDJSON for custom tooling.
+- `docs/features/run.md` — structured `run` payload captured by `git shiplog run`.
+

--- a/docs/features/run.md
+++ b/docs/features/run.md
@@ -48,6 +48,17 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 - Attaches the captured log as a git note under `refs/_shiplog/notes/logs` when an entry is written successfully.
 - Returns the wrapped command’s exit code so it can chain cleanly in scripts or CI pipelines.
 
+### Deployment IDs
+
+- Stamp a first-class Deployment ID on every step with `--deployment <ID>` (or by exporting `SHIPLOG_DEPLOY_ID`).
+- The trailer gains `deployment.id = "<ID>"`. For backward compatibility, if no `--ticket` is provided, the ID is mirrored into `why.ticket`.
+- Tip: mint an ID and export it for the session:
+  ```bash
+  eval "$(scripts/shiplog-deploy-id.sh --export)"  # sets SHIPLOG_DEPLOY_ID
+  git shiplog run --service web -- env printf prechecks
+  git shiplog run --service web -- env printf rollout
+  ```
+
 ### Confirmation Output
 
 - After the wrapped command completes and Shiplog records the entry, it prints a one‑line confirmation.
@@ -80,6 +91,7 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 - `--reason <text>` — Optional free-form description.
 - `--status-success <status>` — Status recorded when the wrapped command exits 0. Default `success`.
 - `--status-failure <status>` — Status recorded when the command fails. Default `failed`.
+- `--deployment <id>` — Stamp `deployment.id=<id>` and mirror to ticket when unset.
 - `--preamble` / `--no-preamble` — Toggle the live preamble and output prefixing for this invocation (overrides env/config).
 - `--ticket <id>`, `--region <r>`, `--cluster <c>`, `--namespace <ns>` — Override standard write metadata.
 

--- a/docs/features/run.md
+++ b/docs/features/run.md
@@ -14,6 +14,11 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 
 - `--service` is required in non-interactive mode (and strongly recommended for clarity).
 - Place the command to execute after `--`; all arguments are preserved and logged.
+ - Place the command to execute after `--`; all arguments are preserved and logged. If you need shell features (globbing, expansions like `$(...)`), pass a shell explicitly, e.g.:
+   ```bash
+   git shiplog run --service deploy -- bash -lc 'echo $(date) && run_deploy'
+   ```
+   Shiplog emits a warning when it sees literal backticks or `$()` tokens in arguments, since those are usually evaluated by your shell before Shiplog can capture them.
 - Successful executions inherit `--status-success` (default `success`); failures use `--status-failure` (default `failed`).
 
 ## Dry Run Mode (`--dry-run`)
@@ -45,10 +50,20 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 
 ### Confirmation Output
 
-- After the wrapped command completes, Shiplog prints a minimal confirmation line.
-- Default: a log emoji only (`🪵`).
-- Customize with `SHIPLOG_CONFIRM_TEXT` (e.g., `> Shiplogged`, `Recorded`).
-- The previous verbose preview is suppressed to keep terminals quiet; use `git shiplog show` if you want to inspect the entry that was written.
+- After the wrapped command completes and Shiplog records the entry, it prints a one‑line confirmation.
+- Default (when not overridden): `🚢🪵⚓️` if an anchor exists for the env, otherwise `🚢🪵✅`.
+- Customize entirely with `SHIPLOG_CONFIRM_TEXT` (e.g., `> Shiplogged`).
+- Suppress with `SHIPLOG_QUIET_ON_SUCCESS=1`.
+
+### Optional Preamble
+
+- Enable a start/end preamble around the command’s live output (console only); the saved note remains unprefixed.
+- Start line defaults to `🚢🪵🎬`; end line defaults to `🚢🪵✅` (success) or `🚢🪵❌` (failure).
+- Turn on via `SHIPLOG_PREAMBLE=1` (or `git config shiplog.preamble true`), or per‑invocation with `--preamble`.
+- Customize glyphs with:
+  - `SHIPLOG_PREAMBLE_START_TEXT`
+  - `SHIPLOG_PREAMBLE_END_TEXT`
+  - `SHIPLOG_PREAMBLE_END_TEXT_FAIL`
 
 ## Exit Codes
 - Dry run
@@ -65,7 +80,10 @@ git shiplog run --dry-run --service deploy --reason "Smoke test" -- env printf h
 - `--reason <text>` — Optional free-form description.
 - `--status-success <status>` — Status recorded when the wrapped command exits 0. Default `success`.
 - `--status-failure <status>` — Status recorded when the command fails. Default `failed`.
+- `--preamble` / `--no-preamble` — Toggle the live preamble and output prefixing for this invocation (overrides env/config).
 - `--ticket <id>`, `--region <r>`, `--cluster <c>`, `--namespace <ns>` — Override standard write metadata.
+
+See also: test/29_run_preamble_and_warnings.bats for executable examples.
 - When there is no output, log attachment is skipped and `log_attached=false` is recorded in the trailer.
 - Confirmation text: set `SHIPLOG_CONFIRM_TEXT` to override the default emoji (see above).
 

--- a/docs/features/write.md
+++ b/docs/features/write.md
@@ -9,7 +9,8 @@ git shiplog write [ENV] \
   [--service NAME] [--status success|failed|in_progress|skipped|override|revert|finalize] \
   [--reason TEXT] [--ticket ID] \
   [--region R] [--cluster C] [--namespace NS] \
-  [--image IMG] [--tag TAG] [--run-url URL]
+  [--image IMG] [--tag TAG] [--run-url URL] \
+  [--log PATH]   # alias: --attach PATH
 
 # Non-interactive
 SHIPLOG_BORING=1 git shiplog --yes write prod --service release --reason "MVP release"
@@ -21,11 +22,12 @@ Tip (non‑interactive/CI): avoid prompts by passing required fields via flags o
 - Validates the author against the resolved allowlist and performs a signing precheck when signatures are required.
 - Prompts for service, status, change details, and artifact information. You can prefill or bypass prompts with flags (`--service`, `--reason`, etc.) or environment variables listed below.
 - Defaults the namespace to the journal environment when left blank (e.g., `prod`).
-- Generates both a human-readable header and a JSON trailer; optionally attaches NDJSON logs via `SHIPLOG_LOG`.
+- Generates both a human-readable header and a JSON trailer; optionally attaches NDJSON logs via `--log/--attach` or `SHIPLOG_LOG`.
 - Human-readable header hides missing location parts: if you only provide `env=prod`, it renders `→ prod` (no placeholders for region/cluster/namespace).
 - Accepts `--yes` to skip confirmation prompts (sets `SHIPLOG_ASSUME_YES=1`).
 - Fast-forwards the journal ref; aborts if the ref is missing or would require a force update.
-- Automatically pushes the updated journal (and attached notes) to `origin` when available; disable with `SHIPLOG_AUTO_PUSH=0` or `--no-push`.
+- Automatically pushes the updated journal (and attached notes) to the configured remote when available; disable with `SHIPLOG_AUTO_PUSH=0` or `--no-push`.
+  - Implementation detail: Shiplog uses `git push --no-verify` for these pushes to avoid triggering repository pre‑push hooks during deployments. Use `git shiplog publish` later if you prefer to push explicitly (it also uses `--no-verify`).
 
 ## Flags and Environment Overrides
 | Variable | Purpose | Accepted values | Default | Example |

--- a/docs/features/write.md
+++ b/docs/features/write.md
@@ -8,6 +8,7 @@
 git shiplog write [ENV] \
   [--service NAME] [--status success|failed|in_progress|skipped|override|revert|finalize] \
   [--reason TEXT] [--ticket ID] \
+  [--deployment ID] \
   [--region R] [--cluster C] [--namespace NS] \
   [--image IMG] [--tag TAG] [--run-url URL] \
   [--log PATH]   # alias: --attach PATH
@@ -23,6 +24,7 @@ Tip (non‑interactive/CI): avoid prompts by passing required fields via flags o
 - Prompts for service, status, change details, and artifact information. You can prefill or bypass prompts with flags (`--service`, `--reason`, etc.) or environment variables listed below.
 - Defaults the namespace to the journal environment when left blank (e.g., `prod`).
 - Generates both a human-readable header and a JSON trailer; optionally attaches NDJSON logs via `--log/--attach` or `SHIPLOG_LOG`.
+- If `--deployment ID` (or `SHIPLOG_DEPLOY_ID`) is provided, the trailer includes `deployment.id = "ID"`. If no `--ticket` is provided, the ID is mirrored to `why.ticket` for backward compatibility.
 - Human-readable header hides missing location parts: if you only provide `env=prod`, it renders `→ prod` (no placeholders for region/cluster/namespace).
 - Accepts `--yes` to skip confirmation prompts (sets `SHIPLOG_ASSUME_YES=1`).
 - Fast-forwards the journal ref; aborts if the ref is missing or would require a force update.

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -24,6 +24,7 @@ This is a compact reference for key `SHIPLOG_*` environment variables. Most can 
 - `SHIPLOG_AUTO_PUSH` — Auto-push Shiplog refs to the configured remote when available (`write`, some `setup` flows)
   - Values: `1` (default) or `0`
   - Precedence: command flags > `git config shiplog.autoPush` > `SHIPLOG_AUTO_PUSH`.
+  - Note: Shiplog invokes `git push --no-verify` for these pushes to avoid triggering pre-push hooks during deployments. Use `git shiplog publish` to push later; it also uses `--no-verify`.
 
 - `SHIPLOG_REMOTE` — Remote name shiplog commands use for fetch/publish/push operations
   - Default: `origin` (or `git config shiplog.remote` when set)
@@ -37,9 +38,22 @@ This is a compact reference for key `SHIPLOG_*` environment variables. Most can 
 
 ## UX
 
-- `SHIPLOG_CONFIRM_TEXT` — Override the confirmation line printed by `git shiplog run` after a successful write.
-  - Default: the log emoji `🪵`
-  - Example: `export SHIPLOG_CONFIRM_TEXT="> Shiplogged"`
+- `SHIPLOG_PREAMBLE` — Enable a start/end preamble around `run` output (console only).
+  - Values: `1|true|yes|on` to enable; `0|false|no|off` to disable (default `0`).
+  - Git config equivalent: `git config shiplog.preamble true`
+  - Related overrides:
+    - `SHIPLOG_PREAMBLE_START_TEXT` (default: `🚢🪵🎬`)
+    - `SHIPLOG_PREAMBLE_END_TEXT` (default: `🚢🪵✅`)
+    - `SHIPLOG_PREAMBLE_END_TEXT_FAIL` (default: `🚢🪵❌`)
+  - CLI toggles for a single invocation: `git shiplog run --preamble` / `--no-preamble`.
+
+- `SHIPLOG_CONFIRM_TEXT` — Override the one-line confirmation printed after a successful entry write.
+  - Default when unset: a context-aware glyph built from `🚢🪵` and:
+    - `⚓️` if an anchor exists for the env, otherwise `✅`.
+  - Example: `export SHIPLOG_CONFIRM_TEXT="> entry recorded"`
+
+- `SHIPLOG_QUIET_ON_SUCCESS` — Suppress the success confirmation line entirely.
+  - Values: `1` to suppress; `0` (default) to print.
 
 ## Policy & Signing
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -55,6 +55,14 @@ This is a compact reference for key `SHIPLOG_*` environment variables. Most can 
 - `SHIPLOG_QUIET_ON_SUCCESS` — Suppress the success confirmation line entirely.
   - Values: `1` to suppress; `0` (default) to print.
 
+## Deployments
+
+- `SHIPLOG_DEPLOY_ID` — First-class deployment identifier stamped on entries.
+  - Scope: honored by `git shiplog run`, `write`, and `append`.
+  - Behavior: when set (or provided via `--deployment ID`), Shiplog writes a dedicated `deployment.id` field into the trailer JSON. For backward compatibility, if no `why.ticket` is provided, Shiplog mirrors the Deployment ID into `why.ticket`.
+  - Minting IDs: use `scripts/shiplog-deploy-id.sh` to generate a sortable id (ULID if available, else UUID, else a timestamp+sha fallback). Example:
+    - `eval "$(scripts/shiplog-deploy-id.sh --export)"` then run your steps; all entries in that shell inherit the ID.
+
 ## Policy & Signing
 
 - `SHIPLOG_AUTHORS` — Space-separated allowlist of authors (emails). Overrides policy.

--- a/docs/reference/json-schema.md
+++ b/docs/reference/json-schema.md
@@ -41,6 +41,7 @@ This document captures the layout of the JSON trailer that `git shiplog` writes 
   "seq": 17,
   "journal_parent": "0d135ab...",
   "trust_oid": "63c2d9c...",
+  "deployment": { "id": "REL-2025-09-30.1" },
   "previous_anchor": null,
   "repo_head": "0f4e7890...",
   "run": {
@@ -162,6 +163,12 @@ The `run` block appears when the entry was produced by `git shiplog run`. Its sh
     "journal_parent": {"type": ["string", "null"]},
     "trust_oid": {"type": "string"},
     "previous_anchor": {"type": ["string", "null"]},
+    "deployment": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"}
+      }
+    },
     "repo_head": {"type": "string"},
     "run": {
       "type": "object",

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script sets up a development environment for shiplog by symlinking
+# the local git repository to the standard shiplog installation directory.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_DIR="${SHIPLOG_HOME:-$HOME/.shiplog}"
+
+log() {
+  echo "[shiplog-dev-install] $*"
+}
+
+log "Repository root: $REPO_ROOT"
+log "Install directory: $INSTALL_DIR"
+
+if [ -e "$INSTALL_DIR" ] || [ -L "$INSTALL_DIR" ]; then
+  log "Removing existing installation at $INSTALL_DIR"
+  rm -rf "$INSTALL_DIR"
+fi
+
+log "Creating symlink: $INSTALL_DIR -> $REPO_ROOT"
+ln -s "$REPO_ROOT" "$INSTALL_DIR"
+
+cat <<INFO
+
+Shiplog dev mode enabled!
+The directory '$INSTALL_DIR' now points to your local repository.
+
+To use the 'git-shiplog' command, ensure '$INSTALL_DIR/bin' is in your PATH.
+You can do this by adding the following to your shell profile (~/.zshrc, ~/.bashrc, etc.):
+
+  export SHIPLOG_HOME="$INSTALL_DIR"
+  export PATH="\$SHIPLOG_HOME/bin:\$PATH"
+
+Reload your shell for changes to take effect.
+Then test with:
+  git shiplog --version
+INFO

--- a/scripts/shiplog-deploy-id.sh
+++ b/scripts/shiplog-deploy-id.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+need() { command -v "$1" >/dev/null 2>&1; }
+
+mint_id() {
+  if need ulid; then
+    ulid
+    return
+  fi
+  if need uuidgen; then
+    uuidgen | tr 'A-Z' 'a-z'
+    return
+  fi
+  printf 'rel-%s-%s-%06x\n' \
+    "$(date -u +%Y%m%dT%H%M%SZ)" \
+    "$(git rev-parse --short=8 HEAD 2>/dev/null || echo 00000000)" \
+    "$RANDOM$RANDOM"
+}
+
+EXPORT=0
+ID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --id) shift; ID="${1:-}"; shift; continue ;;
+    --export|-x) EXPORT=1; shift; continue ;;
+    --help|-h) echo "usage: $0 [--id ID] [--export]"; exit 0 ;;
+    --) shift; break ;;
+    *) echo "❌ unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$ID" ] || ID="$(mint_id)"
+
+if [ "$EXPORT" -eq 1 ]; then
+  echo "export SHIPLOG_DEPLOY_ID=$ID"
+else
+  echo "$ID"
+fi
+

--- a/scripts/shiplog-replay.sh
+++ b/scripts/shiplog-replay.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shiplog-replay.sh — experimental log replay for Shiplog journals
+#
+# Replays a sequence of Shiplog entries from a journal, printing each entry's
+# summary and (optionally) attached log notes. Timing is simulated using the
+# recorded run duration when present, with a configurable speed multiplier.
+#
+# Usage:
+#   scripts/shiplog-replay.sh [--env ENV] [--from SHA] [--to SHA] \
+#     [--count N] [--speed X] [--no-notes] [--compact] [--step]
+#
+# Defaults:
+#   --env ${SHIPLOG_ENV:-prod}
+#   --count 5
+#   --speed 1.0  (use 0 for fastest replay without sleeps)
+#
+# Notes:
+#   - This is a read-only helper. It does not modify refs.
+#   - Attached notes are printed as saved; they are not timestamped per line.
+#     When a run duration is present, lines are paced uniformly across it.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REF_ROOT="${SHIPLOG_REF_ROOT:-refs/_shiplog}"
+NOTES_REF="${SHIPLOG_NOTES_REF:-refs/_shiplog/notes/logs}"
+ENV_NAME="${SHIPLOG_ENV:-prod}"
+FROM_SHA=""
+TO_SHA=""
+COUNT=5
+SPEED=1.0
+PRINT_NOTES=1
+COMPACT=0
+STEP=0
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "❌ Missing dependency: $1" >&2; exit 1; }; }
+need git
+need jq
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) shift; ENV_NAME="${1:-$ENV_NAME}"; shift; continue ;;
+    --env=*) ENV_NAME="${1#*=}"; shift; continue ;;
+    --from) shift; FROM_SHA="${1:-}"; shift; continue ;;
+    --from=*) FROM_SHA="${1#*=}"; shift; continue ;;
+    --to) shift; TO_SHA="${1:-}"; shift; continue ;;
+    --to=*) TO_SHA="${1#*=}"; shift; continue ;;
+    --count) shift; COUNT="${1:-$COUNT}"; shift; continue ;;
+    --count=*) COUNT="${1#*=}"; shift; continue ;;
+    --speed) shift; SPEED="${1:-$SPEED}"; shift; continue ;;
+    --speed=*) SPEED="${1#*=}"; shift; continue ;;
+    --no-notes) PRINT_NOTES=0; shift; continue ;;
+    --compact) COMPACT=1; shift; continue ;;
+    --step) STEP=1; shift; continue ;;
+    --help|-h)
+      cat <<EOF
+Usage: scripts/shiplog-replay.sh [OPTIONS]
+
+Options:
+  --env ENV           Journal environment (default: ${SHIPLOG_ENV:-prod})
+  --from SHA          Start at this entry (inclusive). If omitted, start from tip.
+  --to SHA            Stop at (and include) this entry.
+  --count N           Limit number of entries (default: 5)
+  --speed X           Speed multiplier (default: 1.0). 0 = fastest (no sleeps)
+  --no-notes          Do not print attached notes (logs)
+  --compact           Print summary lines only (no JSON trailer)
+  --step              Pause for Enter between entries instead of sleeping
+EOF
+      exit 0
+      ;;
+    --) shift; break ;;
+    *) echo "❌ Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+JOURNAL_REF="$REF_ROOT/journal/$ENV_NAME"
+git rev-parse --verify "$JOURNAL_REF" >/dev/null 2>&1 || { echo "❌ No journal at $JOURNAL_REF" >&2; exit 1; }
+
+# Build rev-list range
+RANGE=("$JOURNAL_REF")
+[ -n "$TO_SHA" ] && RANGE=("$TO_SHA".."$JOURNAL_REF")
+[ -n "$FROM_SHA" ] && RANGE+=("^$FROM_SHA")
+
+mapfile -t COMMITS < <(git rev-list --max-count="$COUNT" "${RANGE[@]}")
+[ "${#COMMITS[@]}" -gt 0 ] || { echo "ℹ️ No entries to replay"; exit 0; }
+
+render_entry() {
+  local c="$1"
+  local body json
+  body="$(git show -s --format=%B "$c")"
+  json="$(awk 'BEGIN{p=0} /^---$/{p=1;next} p{print}' <<<"$body")"
+
+  local service env status ts seq author repo_head dur_s started finished
+  service="$(jq -r '.what.service // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  env="$(jq -r '.env // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  status="$(jq -r '.status // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  ts="$(jq -r '.ts // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  seq="$(jq -r '.seq // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  author="$(jq -r '.who.email // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  repo_head="$(jq -r '.repo_head // "?"' <<<"$json" 2>/dev/null || echo "?")"
+  dur_s=$(jq -r '(.run.duration_s // .when.dur_s // 0)' <<<"$json" 2>/dev/null || echo 0)
+  started="$(jq -r '(.run.started_at // .when.start_ts // "")' <<<"$json" 2>/dev/null || echo "")"
+  finished="$(jq -r '(.run.finished_at // .when.end_ts // "")' <<<"$json" 2>/dev/null || echo "")"
+
+  local header
+  header=$(cat <<EOF
+▶ ${service} → ${env}  |  status=${status}  seq=${seq}  ts=${ts}
+   author=${author}  repo=${repo_head}
+EOF
+)
+  printf '%s\n' "$header"
+
+  if [ "$COMPACT" -eq 0 ]; then
+    printf '%s\n' "$json" | jq -C -S . || printf '%s\n' "$json"
+  fi
+
+  if [ "$PRINT_NOTES" -eq 1 ]; then
+    if git notes --ref="$NOTES_REF" show "$c" >/dev/null 2>&1; then
+      echo "--- log (notes) ---"
+      local lines
+      if [ "$SPEED" = "0" ]; then
+        git notes --ref="$NOTES_REF" show "$c"
+      else
+        # Pace uniformly across duration (fallback to minimal pacing)
+        local total_lines sleep_per=0.03
+        mapfile -t lines < <(git notes --ref="$NOTES_REF" show "$c")
+        total_lines=${#lines[@]}
+        if [ "$total_lines" -gt 0 ] && [ "$dur_s" -gt 0 ]; then
+          # Distribute sleeps across lines with multiplier
+          sleep_per=$(awk -v d="$dur_s" -v n="$total_lines" -v s="$SPEED" 'BEGIN{ if (s<=0) s=1; sp=(d/n)/s; if(sp<0.01) sp=0.01; print sp }')
+        fi
+        for ln in "${lines[@]}"; do
+          printf '%s\n' "$ln"
+          sleep "$sleep_per"
+        done
+      fi
+      echo "--- end log ---"
+    fi
+  fi
+
+  # Wait between entries: either step or approximate gap by duration
+  if [ "$STEP" -eq 1 ]; then
+    read -r -p "[enter to continue]" _ || true
+  else
+    if [ "$SPEED" != "0" ] && [ "$dur_s" -gt 0 ]; then
+      local gap
+      gap=$(awk -v d="$dur_s" -v s="$SPEED" 'BEGIN{ if (s<=0) s=1; g=d/s; if(g>3) g=3; print g }')
+      sleep "$gap"
+    fi
+  fi
+}
+
+for c in "${COMMITS[@]}"; do
+  render_entry "$c"
+  echo
+done
+
+echo "✅ replay complete (${#COMMITS[@]} entries)"
+

--- a/scripts/shiplog-replay.sh
+++ b/scripts/shiplog-replay.sh
@@ -89,10 +89,11 @@ RANGE=("$JOURNAL_REF")
 [ -n "$FROM_SHA" ] && RANGE+=("^$FROM_SHA")
 
 if [ -n "$DEPLOY_ID" ]; then
+  # Reverse order (oldest first) without relying on non-POSIX tac
   mapfile -t COMMITS < <(
     git shiplog export-json "$ENV_NAME" \
       | jq -r --arg id "$DEPLOY_ID" 'select((.deployment.id // "") == $id or (.why.ticket // "") == $id) | .commit' \
-      | tac
+      | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--) print a[i]}'
   )
 else
   mapfile -t COMMITS < <(git rev-list --max-count="$COUNT" "${RANGE[@]}")

--- a/test/27_verify_shows_reason.bats
+++ b/test/27_verify_shows_reason.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+REF_ROOT=${SHIPLOG_REF_ROOT:-refs/_shiplog}
+
+setup() {
+  shiplog_standard_setup
+  git shiplog init >/dev/null
+  export SHIPLOG_AUTO_PUSH=0
+}
+
+teardown() {
+  shiplog_standard_teardown
+  unset SHIPLOG_AUTO_PUSH
+}
+
+@test "verify surfaces reason when entries are unsigned" {
+  # Write an unsigned entry
+  run bash -lc 'SHIPLOG_BORING=1 git shiplog --yes write prod --service demo'
+  [ "$status" -eq 0 ]
+
+  # Prepare a readable allowed_signers file so signature verification gate can run
+  mkdir -p .shiplog
+  printf '# dummy allowed signers (unused for unsigned)\n' > .shiplog/allowed_signers
+
+  # Force signature verification for verify and expect a helpful reason
+  run bash -lc 'SHIPLOG_SIGN=1 SHIPLOG_ALLOWED_SIGNERS=.shiplog/allowed_signers git shiplog verify prod 2>&1'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bad or missing signature"* ]]
+  [[ "$output" == *"no signature"* ]]
+}
+

--- a/test/28_trust_sign_sshkeygen_error.bats
+++ b/test/28_trust_sign_sshkeygen_error.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+setup() {
+  shiplog_standard_setup
+}
+
+teardown() {
+  shiplog_standard_teardown
+}
+
+@test "trust-sign surfaces ssh-keygen failure reason" {
+  # Create a commit containing trust.json so the script can build a payload
+  printf '{"id":"test-root","threshold":1}\n' > trust.json
+  git add trust.json
+  git commit -m "add trust.json" >/dev/null
+  sha=$(git rev-parse HEAD)
+
+  # Configure an invalid signing key (empty file) to trigger ssh-keygen error
+  touch badkey
+  chmod 600 badkey
+  git config user.signingkey "$(pwd)/badkey"
+
+  run bash -lc "${SHIPLOG_PROJECT_ROOT}/scripts/shiplog-trust-sign.sh ${sha} 2>&1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ssh-keygen failed to sign payload"* ]]
+}
+

--- a/test/29_run_preamble_and_warnings.bats
+++ b/test/29_run_preamble_and_warnings.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+REF_ROOT=${SHIPLOG_REF_ROOT:-refs/_shiplog}
+
+setup() {
+  shiplog_standard_setup
+  git shiplog init >/dev/null
+  export SHIPLOG_SIGN=0
+  export SHIPLOG_AUTO_PUSH=0
+}
+
+teardown() {
+  shiplog_standard_teardown
+  unset SHIPLOG_SIGN SHIPLOG_AUTO_PUSH
+}
+
+@test "run --preamble streams output and prints start/end glyphs (success)" {
+  run bash -lc 'git shiplog run --preamble --service test -- env printf hi'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"🚢🪵🎬"* ]]
+  [[ "$output" == *" |  hi"* ]]
+  [[ "$output" == *"🚢🪵✅"* ]]
+}
+
+@test "run --preamble prints failure end glyph and returns non-zero" {
+  run bash -lc 'git shiplog run --preamble --service test -- /bin/false'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"🚢🪵🎬"* ]]
+  [[ "$output" == *"🚢🪵❌"* ]]
+}
+
+@test "run exit code matches trailer run.exit_code (success)" {
+  run bash -lc 'git shiplog run --service test -- true'
+  [ "$status" -eq 0 ]
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run bash -lc "git shiplog show --json $sha | jq -e '.run.exit_code == 0'"
+  [ "$status" -eq 0 ]
+}
+
+@test "run with no output records log_attached=false" {
+  run bash -lc 'git shiplog run --service test -- true'
+  [ "$status" -eq 0 ]
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run bash -lc "git shiplog show --json $sha | jq -r '.run.log_attached'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "run warns on literal command substitution token in argv" {
+  run bash -lc 'git shiplog run --service test -- echo "\$()"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"detected possible command substitution token"* ]]
+  [[ "$output" == *"$()"* ]]
+}
+
+@test "run --no-preamble suppresses preamble glyphs and prefix" {
+  run bash -lc 'git shiplog run --no-preamble --service test -- env printf hi'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hi"* ]]
+  [[ "$output" != *"🚢🪵🎬"* ]]
+  [[ "$output" != *"🚢🪵✅"* ]]
+  [[ "$output" != *" |  hi"* ]]
+}
+
+@test "run in boring mode prints only confirmation (no streaming) and still attaches log" {
+  run bash -lc 'SHIPLOG_BORING=1 git shiplog run --service test -- env printf hi'
+  [ "$status" -eq 0 ]
+  # No streaming/preamble in boring mode, but a minimal confirmation glyph prints
+  [[ "$output" == *"🪵"* ]]
+  [[ "$output" != *" |  "* ]]
+  [[ "$output" != *"🚢🪵🎬"* ]]
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run bash -lc "git shiplog show --json $sha | jq -r '.run.log_attached'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}

--- a/test/30_write_attach_flag.bats
+++ b/test/30_write_attach_flag.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+REF_ROOT=${SHIPLOG_REF_ROOT:-refs/_shiplog}
+NOTES_REF=${SHIPLOG_NOTES_REF:-refs/_shiplog/notes/logs}
+
+setup() {
+  shiplog_standard_setup
+  git shiplog init >/dev/null
+  export SHIPLOG_SIGN=0
+  export SHIPLOG_AUTO_PUSH=0
+}
+
+teardown() {
+  shiplog_standard_teardown
+  unset SHIPLOG_SIGN SHIPLOG_AUTO_PUSH
+}
+
+@test "write --log PATH attaches note" {
+  tmp_log="${BATS_TMPDIR}/shiplog-write-log-${BATS_TEST_NUMBER:-0}-$RANDOM$RANDOM.ndjson"
+  echo '{"msg":"from --log"}' > "$tmp_log"
+
+  run bash -lc 'git shiplog --yes write --service api --status success --reason "log flag" --log '"$tmp_log"  
+  [ "$status" -eq 0 ]
+
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run git notes --ref="${NOTES_REF}" show "$sha"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"from --log"* ]]
+
+  # write-only entries do not include a .run block
+  run bash -lc "git shiplog show --json $sha | jq -e 'has(\"run\") | not'"
+  [ "$status" -eq 0 ]
+
+  rm -f "$tmp_log"
+}
+
+@test "write --attach PATH attaches note (alias)" {
+  tmp_log="${BATS_TMPDIR}/shiplog-write-attach-${BATS_TEST_NUMBER:-0}-$RANDOM$RANDOM.ndjson"
+  echo '{"msg":"from --attach"}' > "$tmp_log"
+
+  run bash -lc 'git shiplog --yes write --service api --status success --reason "attach flag" --attach '"$tmp_log"  
+  [ "$status" -eq 0 ]
+
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run git notes --ref="${NOTES_REF}" show "$sha"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"from --attach"* ]]
+
+  # write-only entries do not include a .run block
+  run bash -lc "git shiplog show --json $sha | jq -e 'has(\"run\") | not'"
+  [ "$status" -eq 0 ]
+
+  rm -f "$tmp_log"
+}
+
+@test "write without --log/--attach creates no note" {
+  run bash -lc 'git shiplog --yes write --service api --status success --reason "no note"'
+  [ "$status" -eq 0 ]
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run git notes --ref="${NOTES_REF}" show "$sha"
+  [ "$status" -ne 0 ]
+  # write-only entries do not include a .run block
+  run bash -lc "git shiplog show --json $sha | jq -e 'has(\"run\") | not'"
+  [ "$status" -eq 0 ]
+  # human output should not include an Attached Log section
+  run bash -lc "git shiplog show $sha"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Attached Log (notes)"* ]]
+}

--- a/test/31_deploy_id_and_replay.bats
+++ b/test/31_deploy_id_and_replay.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+REF_ROOT=${SHIPLOG_REF_ROOT:-refs/_shiplog}
+
+setup() {
+  shiplog_standard_setup
+  git shiplog init >/dev/null
+  export SHIPLOG_AUTO_PUSH=0
+}
+
+teardown() {
+  shiplog_standard_teardown
+  unset SHIPLOG_AUTO_PUSH
+}
+
+@test "run --deployment stamps deployment.id and mirrors ticket when empty" {
+  run bash -lc 'git shiplog run --deployment DEP-123 --service test -- true'
+  [ "$status" -eq 0 ]
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run bash -lc "git shiplog show --json $sha | jq -e '.deployment.id==\"DEP-123\" and .why.ticket==\"DEP-123\"'"
+  [ "$status" -eq 0 ]
+}
+
+@test "append --deployment adds deployment.id and keeps explicit ticket" {
+  run bash -lc 'git shiplog append --env prod --service test --ticket T-1 --deployment DEP-999 --json "{}"'
+  [ "$status" -eq 0 ]
+  sha=$(git rev-parse "${REF_ROOT}/journal/prod")
+  run bash -lc "git shiplog show --json $sha | jq -e '.deployment.id==\"DEP-999\" and .why.ticket==\"T-1\"'"
+  [ "$status" -eq 0 ]
+}
+
+@test "replay --deployment filters entries by id" {
+  run bash -lc '
+    eval "$(scripts/shiplog-deploy-id.sh --export)" && id="$SHIPLOG_DEPLOY_ID" && \
+    git shiplog run --service test -- true && \
+    other=$(scripts/shiplog-deploy-id.sh) && SHIPLOG_DEPLOY_ID="$other" git shiplog run --service test -- true && \
+    scripts/shiplog-replay.sh --env prod --deployment "$id" --count 100 --speed 0 > out.txt && \
+    grep -c "▶" out.txt
+  '
+  [ "$status" -eq 0 ]
+  # Expect at least 1 entry and not both
+  [ "$output" -eq 1 ]
+}
+

--- a/test/32_replay_wrapper.bats
+++ b/test/32_replay_wrapper.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+setup() {
+  shiplog_standard_setup
+  git shiplog init >/dev/null
+  export SHIPLOG_AUTO_PUSH=0
+}
+
+teardown() {
+  shiplog_standard_teardown
+  unset SHIPLOG_AUTO_PUSH
+}
+
+@test "replay wrapper runs via --deployment" {
+  run bash -lc '
+    eval "$(scripts/shiplog-deploy-id.sh --export)"
+    git shiplog run --deployment "$SHIPLOG_DEPLOY_ID" --service test -- bash -lc "printf A"
+    git shiplog replay --deployment "$SHIPLOG_DEPLOY_ID" --env prod --count 50 --speed 0
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"▶"* ]]
+  [[ "$output" == *"A"* ]]
+}
+
+@test "replay --since-anchor resolves start boundary" {
+  run bash -lc '
+    git shiplog anchor set --env prod --reason start >/dev/null || true
+    git shiplog run --service test -- bash -lc "printf B"
+    git shiplog replay --env prod --since-anchor --count 50 --speed 0
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"B"* ]]
+}
+
+@test "replay --pointer uses reflog window when available" {
+  run bash -lc '
+    ref="refs/_shiplog/deploy/prod"
+    git update-ref -m "start deployment" "$ref" "$(git rev-parse refs/_shiplog/journal/prod)"
+    git shiplog run --service test -- bash -lc "printf C"
+    git update-ref -m "end deployment" "$ref" "$(git rev-parse refs/_shiplog/journal/prod)"
+    git shiplog replay --pointer "$ref" --env prod --speed 0
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C"* ]]
+}
+

--- a/test/33_anchor_commands.bats
+++ b/test/33_anchor_commands.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load helpers/common
+
+setup() {
+  shiplog_standard_setup
+  git shiplog init >/dev/null
+  export SHIPLOG_AUTO_PUSH=0
+}
+
+teardown() {
+  shiplog_standard_teardown
+  unset SHIPLOG_AUTO_PUSH
+}
+
+@test "anchor set/show/list" {
+  run bash -lc '
+    git shiplog run --service test -- bash -lc "printf hi" >/dev/null
+    git shiplog anchor set --env prod --reason "start deploy"
+    git shiplog anchor show --env prod
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"anchor set"* ]]
+  [[ "$output" == *"⚓️"* ]]
+
+  run bash -lc 'git shiplog anchor list --env prod'
+  [ "$status" -eq 0 ]
+}
+
+@test "replay --since-anchor uses anchor boundary" {
+  run bash -lc '
+    git shiplog anchor set --env prod --reason before >/dev/null
+    git shiplog run --service test -- bash -lc "printf AFTER"
+    git shiplog replay --env prod --since-anchor --count 50 --speed 0
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AFTER"* ]]
+}
+


### PR DESCRIPTION
Adds --deployment/SHIPLOG_DEPLOY_ID with trailer deployment.id (mirrored to why.ticket when unset), git shiplog replay wrapper + script with --since-anchor/--pointer/--tag, and anchor set|show|list. Includes docs and tests.